### PR TITLE
Feature/itables upgrade

### DIFF
--- a/deploy_mode.txt
+++ b/deploy_mode.txt
@@ -1,1 +1,1 @@
-both
+none

--- a/deploy_mode.txt
+++ b/deploy_mode.txt
@@ -1,1 +1,1 @@
-none
+test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "shinylims-uv"
-version = "0.1.0"
+version = "0.2.1"
 authors = [
   { name="Magnus Leithaug", email="magnus.leithaug@vetinst.no" },
 ]
@@ -15,8 +15,12 @@ dependencies = [
     "pins==0.8.5",
     "python-dotenv>=1.0.1",
     "seaborn==0.13.2",
-    "shiny==0.9.0",
+    "shiny==1.3.0",
     "shinyswatch==0.6.1",
+    "plotly==6.0.1",
+    "shinywidgets==0.5.1",
+    "tomli==2.2.1"
+
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.11.5"
 dependencies = [
     "faicons==0.2.2",
-    "itables==2.0.1",
+    "itables==2.2.5",
     "pandas==2.2.2",
     "pins==0.8.5",
     "python-dotenv>=1.0.1",

--- a/src/shinylims/tables/projects.py
+++ b/src/shinylims/tables/projects.py
@@ -2,13 +2,10 @@
 projects.py - Table module containing UI and server logic for the Projects table tab
 '''
 
-from shiny import render, ui, reactive
-from faicons import icon_svg
+from shiny import render, ui
 from itables.shiny import DT
 import pandas as pd
-import datetime
-import pytz
-
+from itables.javascript import JavascriptFunction
 
 ##############################
 # UI PROJECT TABLE
@@ -16,219 +13,144 @@ import pytz
 
 def projects_ui():
     return ui.div(
-        ui.tags.style("""
-            /* Custom styling for the projects nav tabs */
-            #projects_navset .nav-link.active { 
-                font-size: 1.5rem !important; 
-            }
-        """),
-        
-        ui.h2("\u00A0", class_="mb-3 text-center"),
-        ui.navset_tab(
-            ui.nav_panel("Table  (Nov 2023 ->)",
-                ui.div(
-                    ui.accordion(
-                        ui.accordion_panel(
-                            ui.output_text("filters_title_projects"),
-                            ui.row(ui.column(3,
-                                ui.input_date_range(
-                                    id="date_range_projects", 
-                                    label="Open Date Range",
-                                    start=None,
-                                    end=None,
-                                ),
-                                ui.input_action_button(
-                                    id="reset_date_projects", 
-                                    label="Reset Date Filter",
-                                ),),
-                                ui.column(3,
-                                    ui.input_checkbox(
-                                        id="project_comment_filter",
-                                        label="Show only projects with 'Comment'"
-                                    ))),
-                                value="filters", icon=icon_svg("filter"),
-                        ),
-                        ui.accordion_panel(
-                            ui.output_text("column_selection_title_projects"), 
-                            ui.div(
-                                ui.div(
-                                    ui.div(
-                                        ui.input_checkbox_group(
-                                            id="fields_to_display_projects",
-                                            inline=False,
-                                            label=ui.div("Field Selection", class_="fw-bold"),
-                                            choices=[],
-                                            selected=[],
-                                        ),
-                                    ),
-                                )
-                            ),
-                            open=False,
-                            value="column_selection_projects",
-                            icon=icon_svg("table-columns")
-                        ),
-                        class_="mb-3 mt-3",
-                        open=False,
-                        multiple=False
-                    ),
-                    class_="mb-3"
-                ),
-                
-                ui.output_ui("data_projects")
-            ),
-            ui.nav_panel("Info", ui.card(ui.output_ui("projects_info"))), id="projects_navset"
-        )
-)
-
+        ui.output_ui("data_projects")
+    )
 
 ##############################
 # SERVER PROJECT TABLE
 ##############################
 
 def projects_server(input, output, session, projects_df, project_date_created):
-    # Define a reactive value to store the filtered dataframe
-    projects_filtered_data = reactive.Value(projects_df)
 
     @render.ui
     def data_projects():
-        # Filter data using selected date range filter
-        start_date, end_date = input.date_range_projects()
-        filtered_df = projects_df[
-            (projects_df['Open Date'].isna()) |
-            ((projects_df['Open Date'] >= pd.to_datetime(start_date)) &
-            (projects_df['Open Date'] <= pd.to_datetime(end_date)))]
+        dat = projects_df.copy().reset_index(drop=True)
         
-        # Filter data using the "show projects with comment only"-button
-        project_comment_filter = input.project_comment_filter()
-        if project_comment_filter == True:
-            filtered_df = filtered_df[filtered_df['Comment'] != '']
-
-        # Pandas will insert indexing, which we dont want
-        dat = filtered_df.reset_index(drop=True)
-
-        # Store selected columns in variable and set the filtered df in reactive value 
-        selected_columns = list(input.fields_to_display_projects())
-        projects_filtered_data.set(filtered_df)
+        # Properly format date columns for DataTables
+        if "Open Date" in dat.columns:
+            # Convert to datetime type first
+            dat["Open Date"] = pd.to_datetime(dat["Open Date"], errors='coerce')
+            
+            # Format dates as strings in a consistent format for display
+            # Keep NaT values as empty strings
+            dat["Open Date"] = dat["Open Date"].apply(
+                lambda x: x.strftime('%Y-%m-%d') if pd.notna(x) else ''
+            )
         
-        # Get index for the comment section (used for css styling in DT below)
-        if 'Comment' in dat[selected_columns].columns:
-            comment_index = dat[selected_columns].columns.get_loc('Comment')
+        # Get index for the comment section (used for css styling)
+        if 'Comment' in dat.columns:
+            comment_index = dat.columns.get_loc('Comment')
         else:
             comment_index = "Dummy"
+        
+        # Find index for order column (typically Open Date)
+        if 'Open Date' in dat.columns:
+            order_column_index = dat.columns.get_loc('Open Date')
+            date_column_index = order_column_index  # Store for columnDefs
+        else:
+            order_column_index = 0  # Default to first column if Open Date not found
+            date_column_index = -1  # Indicates no date column found
 
         # Return HTML tag with DT table element
-        return ui.HTML(DT(dat[selected_columns], 
-                         select = True, 
-                         layout={"topEnd": "search"}, 
+        return ui.HTML(DT(dat, 
+                         select=True, 
+                         layout={"topEnd": "search", "top1": "searchBuilder"}, 
                          column_filters="footer", 
                          search={"smart": True, "regex": True, "caseInsensitive": True},
-                         lengthMenu=[[50, 100, 200, 500, -1], [50, 100, 200, 500, "All" ]], 
+                         lengthMenu=[[200, 500, 1000, 2000, -1], [200, 500, 1000, 2000, "All"]],  
                          classes="compact hover order-column cell-border", 
                          scrollY="750px",
                          paging=True,
                          maxBytes=0, 
                          autoWidth=True,
                          keys=True,
-                         buttons=["pageLength", 
-                                  "copyHtml5",
-                                 {"extend": "csvHtml5", "title": "WGS Sample Data"},
-                                 {"extend": "excelHtml5", "title": "WGS Sample Data"},],
-                         order=[[0, "desc"]],
-                         columnDefs=[{'targets': comment_index, 'className': 'left-column'},{"className": "dt-center", "targets": "_all"}],))
+                         buttons=[
+                            {'extend': "spacer",
+                             'style': 'bar',
+                             'text': 'Column Settings'},
+                            # Column visibility toggle
+                            {
+                                "extend": "colvis",
+                                "text": "Selection"
+                            },
+                            {'extend': "spacer"},
+                            # Button to deselect all columns
+                            {
+                                "text": "Deselect All",
+                                "action": JavascriptFunction("""
+                                function(e, dt, node, config) {
+                                    dt.columns().visible(false);
+                                }
+                                """)
+                            },
+                            # Button to select all columns
+                            {
+                                "text": "Select All",
+                                "action": JavascriptFunction("""
+                                function(e, dt, node, config) {
+                                    dt.columns().visible(true);
+                                }
+                                """)
+                            },
+                            {'extend': "spacer",
+                             'style': 'bar',
+                             'text': 'Page Length'},
+                            # Page length selector
+                            "pageLength",
+                            {'extend': "spacer",
+                             'style': 'bar',
+                             'text': 'Export'},
+                            # Collection of export options
+                            {
+                                "extend": "collection", 
+                                "text": "Type",
+                                "buttons": [
+                                    # Copy to clipboard
+                                    {
+                                        "extend": "copyHtml5",
+                                        "exportOptions": {"columns": ":visible"}
+                                    },
+                                    # CSV export with all visible columns
+                                    {
+                                        "extend": "csvHtml5", 
+                                        "exportOptions": {"columns": ":visible"},
+                                        "text": "CSV (All Visible)",
+                                        "title": "Project Data Export - Full"
+                                    },
+                                    # Excel export with visible columns
+                                    {
+                                        "extend": "excelHtml5", 
+                                        "exportOptions": {"columns": ":visible"},
+                                        "title": "Project Data Export"
+                                    }
+                                ]
+                            },
+                            {'extend': "spacer",
+                             'style': 'bar'},
+                         ],
+                         order=[[order_column_index, "desc"]],
+                         columnDefs=[
+                            {'targets': comment_index, 'className': 'left-column'},
+                            {"className": "dt-center", "targets": "_all"},
+                            # Explicitly define the Open Date column as a date type for searchBuilder
+                            {
+                                "targets": date_column_index,
+                                "type": "date",
+                                "render": JavascriptFunction("""
+                                function(data, type, row) {
+                                    // For sorting and filtering
+                                    if (type === 'sort' || type === 'type' || type === 'filter') {
+                                        if (!data || data === '') {
+                                            return null;
+                                        }
+                                        return data;
+                                    }
+                                    // For display
+                                    return data;
+                                }
+                                """)
+                            }
+                         ]))
 
-    # Define default column checkbox selection
-    @reactive.Effect
-    def set_default_fields_to_display_projects():
-        ui.update_checkbox_group(
-            "fields_to_display_projects",
-            choices=projects_df.columns.tolist(),
-            selected=['Open Date', 'Status','Project Name', 'Samples', 'Species', 'Submitter', 'Submitting Lab', 'Comment']
-        )    
-    
-    # Define default date range
-    @reactive.Effect
-    def set_default_date_range_projects():
-        try:
-            # Check if 'Open Date' exists and has valid values
-            if 'Open Date' in projects_df.columns:
-                min_date = pd.to_datetime(projects_df['Open Date'], errors='coerce').min()
-                if pd.notna(min_date):
-                    start_date = min_date.date()
-                else:
-                    start_date = datetime.date(2023, 1, 1)  # Fallback
-            else:
-                # Fallback date if column doesn't exist
-                start_date = datetime.date(2023, 1, 1)
-        
-            ui.update_date_range(
-                "date_range_projects",
-                start=start_date,
-                end=datetime.date.today()
-            )
-        except Exception as e:
-            print(f"Error setting default date range for projects: {e}")
-            # Use a reasonable fallback
-            ui.update_date_range(
-                "date_range_projects",
-                start=datetime.date(2023, 1, 1),
-                end=datetime.date.today()
-            )
-
-    # Update date range to default when pressing the reset-button
-    @reactive.Effect
-    @reactive.event(input.reset_date_projects)
-    def reset_date_range_projects():
-        ui.update_date_range(
-            "date_range_projects",
-            start=pd.to_datetime(projects_df['Open Date']).min().date(),
-            end=datetime.date.today()
-        )
-
-    # Render title on filter accordian
-    @render.text
-    def filters_title_projects():
-        start_date, end_date = input.date_range_projects()
-        project_comment_filter = input.project_comment_filter()
-
-        num_filters = 0
-        if start_date != pd.to_datetime(projects_df['Open Date']).min().date() or end_date != datetime.date.today():
-            num_filters += 1
-        if project_comment_filter:
-            num_filters += 1
-
-        total_entries = len(projects_df)
-        filtered_entries = len(projects_filtered_data())
-        filtered_out = total_entries - filtered_entries
-        
-        if num_filters > 0:
-            return f'Filters ({num_filters} filters applied, {filtered_entries} of {total_entries} projects)'
-        else:
-            return f"Filters (All {total_entries} projects shown)"
-
-    # Render title on column selection accordian
-    @render.text
-    def column_selection_title_projects():
-        selected_columns = list(input.fields_to_display_projects())
-        total_columns = len(projects_df.columns)
-        num_selected = len(selected_columns)
-        return f"Column Selection ({num_selected} of {total_columns} columns selected)"
-    
-    @render.ui
-    def projects_info():
-        text = f"<h3>SQL database is updated using these scripts:</h3> \
-        <a href='https://github.com/NorwegianVeterinaryInstitute/nvi_lims_epps/blob/main/shiny_app/update_sqlite.py'>update_sqlite.py (link)</a>\
-        <a href='https://github.com/NorwegianVeterinaryInstitute/nvi_lims_epps/blob/main/shiny_app/update_sqlite_ilmn_seq.py'>update_sqlite_ilmn_seq.py (link)</a> <br>\
-        <h3>Data fields collection </h3> \
-        <p>All fields in this table is collected from submitted sample UDFs directly except for the project sample number which is retrieved using a genologics API-batch function</p> <br> \
-        <h3>Last update to the database (on the clarity server)</h3>\
-        {(datetime.datetime.fromisoformat(project_date_created).astimezone(pytz.timezone('Europe/Berlin'))).strftime('%Y-%m-%d (kl %H:%M)')} \
-        <br> \
-        <p>NOTE: The database on the LIMS server is updated every full hour and synced to the app every 30 minutes past the hour</p> "
-        
-        return ui.HTML(text)
-    
     # Define outputs that need to be returned
     output.data_projects = data_projects
-    output.filters_title_projects = filters_title_projects
-    output.column_selection_title_projects = column_selection_title_projects
-    output.projects_info = projects_info

--- a/src/shinylims/tables/projects.py
+++ b/src/shinylims/tables/projects.py
@@ -118,6 +118,7 @@ def projects_server(input, output, session, projects_df, project_date_created):
 
         # Return HTML tag with DT table element
         return ui.HTML(DT(dat[selected_columns], 
+                         select = True, 
                          layout={"topEnd": "search"}, 
                          column_filters="footer", 
                          search={"smart": True, "regex": True, "caseInsensitive": True},

--- a/src/shinylims/tables/samples.py
+++ b/src/shinylims/tables/samples.py
@@ -240,7 +240,8 @@ def samples_server(input, output, session, samples_df, samples_date_created):
         column_index = selected_columns.index(column_to_sort)
 
         # Return HTML tag with DT table element
-        return ui.HTML(DT(dat[selected_columns], 
+        return ui.HTML(DT(dat[selected_columns],
+                         select = True, 
                          layout={"topEnd": "search"},
                          lengthMenu=[[200, 500, 1000, 2000, -1], [200, 500, 1000, 2000, "All" ]], 
                          column_filters="footer", 

--- a/src/shinylims/tables/samples.py
+++ b/src/shinylims/tables/samples.py
@@ -2,248 +2,79 @@
 samples.py - Table module containing UI and server logic for the Samples table tab
 '''
 
-from shiny import render, ui, reactive
-from faicons import icon_svg
+from shiny import render, ui
 from itables.shiny import DT
 import pandas as pd
-import datetime
-import pytz
+from itables.javascript import JavascriptFunction
 
-# UI definition for the Samples page
+##############################
+# UI SAMPLES TABLE
+##############################
+
 def samples_ui():
     return ui.div(
-        ui.tags.style("""
-            /* Custom styling for the samples nav tabs */
-            #samples_navset .nav-link.active { 
-                font-size: 1.5rem !important; 
-            }
-        """),
+        ui.output_ui("data_samples")
+    )
 
-        ui.h2("\u00A0", class_="mb-3 text-center"),
-        ui.navset_tab(
-        ui.nav_panel("Table (Nov 2023 ->)",
-            ui.div(
-                ui.accordion(
-                    ui.accordion_panel(
-                        ui.output_text("filters_title"), # Dynamic title handled by the server function
-                        ui.row(ui.column(3,
-                            ui.input_date_range(
-                                id="date_range", 
-                                label="Received Date Range",
-                                start=None,
-                                end=None
-                            ),
-                            ui.input_action_button(
-                                id="reset_date", 
-                                label="Reset Date Filter",
-                            ),),
-                            ui.column(3,
-                                ui.input_selectize(
-                                    id="filter_progress", 
-                                    label="Progress", 
-                                    choices=[],
-                                    multiple=True, 
-                                ),),
-                            ui.column(3,
-                                ui.input_selectize(
-                                    id="filter_sample_type", 
-                                    label="Sample Type", 
-                                    choices=[], 
-                                    multiple=True, 
-                                ),),
-                            ui.column(3,
-                                ui.input_selectize(
-                                    id="filter_project_account", 
-                                    label="Project Account", 
-                                    choices=[],
-                                    multiple=True, 
-                                ),),
-                            ui.column(3,   
-                                ui.input_selectize(
-                                    id="filter_experiment_name", 
-                                    label="Experiment Name", 
-                                    choices=[],
-                                    multiple=True
-                                ),),),
-                            value="filters", icon=icon_svg("filter"),
-                    ),
-                    ui.accordion_panel(
-                        ui.output_text("column_selection_title"), # Dynamic title handled by the server function
-                        ui.div(
-                            ui.div(
-                                ui.div(
-                                    ui.input_checkbox_group(
-                                        id="fields_to_display",
-                                        inline=False,
-                                        label=ui.div("Field Selection", class_="fw-bold"),
-                                        choices=[],
-                                        selected=[]
-                                    ),
-                                ),
-                                ui.div(
-                                    ui.input_radio_buttons(
-                                        id="presets",
-                                        label=ui.div("Presets", class_="fw-bold"),
-                                        choices=["All", "All (-IDs,Labels & billinginfo)", "Billing info only", "Custom"],
-                                        selected="All (-IDs,Labels & billinginfo)"
-                                    ),
-                                ),
-                                style="display: flex; align-items: flex-start;" # Places the preset list to the right of checkbox group
-                            )
-                        ),
-                        open=False,
-                        value="column_selection",
-                        icon=icon_svg("table-columns")
-                    ),
-                    class_="mb-3 mt-3",
-                    open=False,
-                    multiple=False
-                ),
-                class_="d-flex flex-column mb-3"
-            ),
-            ui.output_ui("data_samples"),
-        ),
-        ui.nav_panel("Info", ui.card(ui.output_ui("samples_info"))),
-        id="samples_navset"
-    ))
+##############################
+# SERVER SAMPLES TABLE
+##############################
 
 # Server logic for the Samples page
 def samples_server(input, output, session, samples_df, samples_date_created):
-    def get_column_safe(df, column_names, default_value=None):
-        """
-        Safely get a column from a dataframe, trying multiple possible names.
-        Returns default_value if none of the column names exist.
-        """
-        if not isinstance(column_names, list):
-            column_names = [column_names]
-    
-        for col in column_names:
-            if col in df.columns:
-                return df[col]
-    
-        # If we get here, none of the columns exist
-        return pd.Series([default_value] * len(df))
-
-    # Define reactive values
-    filtered_data = reactive.Value(samples_df)
-
-    # Add sample type filter population
-    @reactive.Effect
-    def update_sample_type_choices():
-        # Get unique sample types from the database
-        unique_sample_types = sorted(samples_df['sample_type'].unique().tolist())
-        ui.update_selectize("filter_sample_type", choices=unique_sample_types)
-
-    # Populate the selectize field for project account filter
-    @reactive.Effect
-    def update_project_account_choices():
-        unique_project_accounts = sorted(samples_df['Project Account'].unique().tolist())
-        ui.update_selectize("filter_project_account", choices=unique_project_accounts)
-
-    # Populate the selectize field for Experiment Name filter
-    @reactive.Effect
-    def update_experiment_name_choices():
-        unique_experiment_names = samples_df['Experiment Name'].unique().tolist()
-        ui.update_selectize("filter_experiment_name", choices=unique_experiment_names)
-    
-    # Populate the selectize filed for Progress filter
-    @reactive.Effect
-    def update_progress_choices():
-        # Try multiple possible column names
-        progress_column = get_column_safe(samples_df, ['Progress', 'progress'])
-        if not progress_column.empty:
-            unique_progress = progress_column.unique().tolist()
-            ui.update_selectize("filter_progress", choices=unique_progress)
-        else:
-            ui.update_selectize("filter_progress", choices=["No Progress Data"])
-
-    def get_selected_columns(preset, custom_columns, all_columns):
-        if preset == "All":
-            return all_columns
-        elif preset == "All (-IDs,Labels & billinginfo)":
-            # These columns might have different names in SQLite
-            exclude_patterns = [
-                "limsid", "reagent_label", "label", "billing", "price", "pooling", "invoice"
-            ]
-            return [col for col in all_columns if not any(pattern in col.lower() for pattern in exclude_patterns)]
-        elif preset == "Billing info only":
-            # Try to identify relevant billing columns
-            billing_patterns = ["date", "limsid", "name", "invoice", "bill"]
-            return [col for col in all_columns if any(pattern in col.lower() for pattern in billing_patterns)]
-        elif preset == "Custom":
-            # Make sure all custom columns exist
-            return [col for col in custom_columns if col in all_columns]
-        return []
+    # Helper function to get indices of columns for saga export
+    def get_saga_columns(dataframe):
+        # Define the essential column names - customize this list as needed
+        essential_columns = [
+            "LIMS ID", 
+            "Sample Name",
+            "Species",
+            "Project Account",
+            "NIRD Filename"
+        ]
+        
+        # Get the indices of these columns if they exist in the dataframe
+        column_indices = []
+        for column in essential_columns:
+            if column in dataframe.columns:
+                column_indices.append(dataframe.columns.get_loc(column))
+        
+        # If no essential columns were found, return all columns
+        if not column_indices:
+            return ":visible"
+            
+        return column_indices
 
     # Filter and render the filtered dataframe
     @render.ui
     def data_samples():
-        filtered_df = samples_df.copy()
-
-        # Date filter
-        start_date, end_date = input.date_range()
-        if start_date is not None and end_date is not None:
-            date_col = 'Received Date' if 'Received Date' in filtered_df.columns else 'received_date'
-            if date_col in filtered_df.columns:
-                filtered_df = filtered_df[
-                    (filtered_df[date_col].isna()) | 
-                    ((filtered_df[date_col] >= pd.to_datetime(start_date)) & 
-                    (filtered_df[date_col] <= pd.to_datetime(end_date)))
-                ]
-        # Sample type filter (new)
-        selected_sample_types = input.filter_sample_type()
-        if selected_sample_types:
-            filtered_df = filtered_df[filtered_df['sample_type'].isin(selected_sample_types)]
-
-        selected_project_accounts = input.filter_project_account()
-        if selected_project_accounts:
-            filtered_df = filtered_df[filtered_df['Project Account'].isin(selected_project_accounts)]
+        dat = samples_df.copy().reset_index(drop=True)
         
-        selected_experiment_names = input.filter_experiment_name()
-        if selected_experiment_names:
-            filtered_df = filtered_df[filtered_df['Experiment Name'].isin(selected_experiment_names)]
+        # Properly format date columns for DataTables
+        if "Received Date" in dat.columns:
+            # Convert to datetime type first
+            dat["Received Date"] = pd.to_datetime(dat["Received Date"], errors='coerce')
+            
+            # Format dates as strings in a consistent format for display
+            # Keep NaT values as empty strings
+            dat["Received Date"] = dat["Received Date"].apply(
+                lambda x: x.strftime('%Y-%m-%d') if pd.notna(x) else ''
+            )
         
-        selected_progress = input.filter_progress()
-        if selected_progress:
-            filtered_df = filtered_df[filtered_df['progress'].isin(selected_progress)]
-
-        # Get selected columns
-        try:
-            selected_columns = get_selected_columns(input.presets(), list(input.fields_to_display()), filtered_df.columns.tolist())
-            
-            # Check if any selected columns don't exist in the dataframe
-            missing_columns = [col for col in selected_columns if col not in filtered_df.columns]
-            if missing_columns:
-                print(f"Warning: These selected columns do not exist in the dataframe: {missing_columns}")
-                # Remove missing columns
-                selected_columns = [col for col in selected_columns if col in filtered_df.columns]
-            
-            if not selected_columns:
-                # If no valid columns, use all columns
-                selected_columns = filtered_df.columns.tolist()
-            
-        except Exception as e:
-            print(f"Error getting selected columns: {e}")
-            # Fall back to all columns
-            selected_columns = filtered_df.columns.tolist()
-
-        # Reset index and update reactive value
-        dat = filtered_df.reset_index(drop=True)
-        filtered_data.set(filtered_df)
-        
-        # Print info for debugging
-        print(f"Table will display {len(dat)} rows and {len(selected_columns)} columns")
-        print(f"Sample of column names: {selected_columns[:5]}")
-
-        #Find index for order column
+        # Find index for order column
         column_to_sort = "Received Date"
-        column_index = selected_columns.index(column_to_sort)
+        if column_to_sort in dat.columns:
+            column_index = dat.columns.get_loc(column_to_sort)
+            date_column_index = column_index  # Store for columnDefs
+        else:
+            column_index = 0  # Default to first column if Received Date not found
+            date_column_index = -1  # Indicates no date column found
 
         # Return HTML tag with DT table element
-        return ui.HTML(DT(dat[selected_columns],
-                         select = True, 
-                         layout={"topEnd": "search"},
-                         lengthMenu=[[200, 500, 1000, 2000, -1], [200, 500, 1000, 2000, "All" ]], 
+        return ui.HTML(DT(dat,
+                         select=True, 
+                         layout={"topEnd": "search", "top1": "searchBuilder"},
+                         lengthMenu=[[200, 500, 1000, 2000, -1], [200, 500, 1000, 2000, "All"]], 
                          column_filters="footer", 
                          search={"smart": True},
                          classes="nowrap compact hover order-column cell-border", 
@@ -252,145 +83,107 @@ def samples_server(input, output, session, samples_df, samples_date_created):
                          autoWidth=True,
                          maxBytes=0, 
                          keys=True,
-                         buttons=["pageLength", 
-                                  "copyHtml5",
-                                 {"extend": "csvHtml5", "title": "Sample Data"},
-                                 {"extend": "excelHtml5", "title": "Sample Data"},],
+                         buttons=[
+                            {'extend': "spacer",
+                             'style': 'bar',
+                             'text': 'Column Settings'},
+                            # Column visibility toggle
+                            {
+                                "extend": "colvis",
+                                "text": "Selection"
+                            },
+                            {'extend': "spacer"},
+                            # Button to deselect all columns
+                            {
+                                "text": "Deselect All",
+                                "action": JavascriptFunction("""
+                                function(e, dt, node, config) {
+                                    dt.columns().visible(false);
+                                }
+                                """)
+                            },
+                            # Button to select all columns
+                            {
+                                "text": "Select All",
+                                "action": JavascriptFunction("""
+                                function(e, dt, node, config) {
+                                    dt.columns().visible(true);
+                                }
+                                """)
+                            },
+                            {'extend': "spacer",
+                             'style': 'bar',
+                             'text': 'Page Length'},
+                            # Page length selector
+                            "pageLength",
+                            {'extend': "spacer",
+                             'style': 'bar',
+                             'text': 'Export'},
+                            # Collection of export options
+                            {
+                                "extend": "collection", 
+                                "text": "Type",
+                                "buttons": [
+                                    # Copy to clipboard
+                                    {
+                                        "extend": "copyHtml5",
+                                        "exportOptions": {"columns": ":visible"},
+                                        "text": "Copy to Clipboard"
+                                    },
+
+                                    # CSV export with all visible columns
+                                    {
+                                        "extend": "csvHtml5", 
+                                        "exportOptions": {"columns": ":visible"},
+                                        "text": "Export to CSV",
+                                        "title": "Sample Data Export"
+                                    },
+                                    # Excel export with visible columns
+                                    {
+                                        "extend": "excelHtml5", 
+                                        "exportOptions": {"columns": ":visible"},
+                                        "text": "Export to Excel",
+                                        "title": "Sample Data Export"
+                                    },
+                                    # CSV export with specific columns for Saga
+                                    {
+                                        "extend": "csvHtml5", 
+                                        "exportOptions": {
+                                            "columns": get_saga_columns(dat)
+                                        },
+                                        "text": "Export CSV for Saga", 
+                                        "title": "saga_export"
+                                    },
+                                ]
+                            },
+                            {'extend': "spacer",
+                             'style': 'bar'},
+                         ],
                          order=[[column_index, "desc"]],
                          columnDefs=[
-                         {"className": "dt-center", "targets": "_all"},
-                         {"width": "200px", "targets": "_all"}]  # Set a default width for all columns
-                         )) 
-
-    # Define default column checkbox selection
-    @reactive.Effect
-    def set_default_fields_to_display():
-        # Get all columns that would be displayed by default
-        exclude_patterns = [
-            "limsid", "reagent_label", "label", "billing", "price", "pooling", "invoice"
-        ]
-        default_columns = [col for col in samples_df.columns if not any(pattern in col.lower() for pattern in exclude_patterns)]
-    
-        ui.update_checkbox_group(
-            "fields_to_display",
-            choices=samples_df.columns.tolist(),
-            selected=default_columns
-        )
-    
-    # Make sure "Received Date" column isnt deselected
-    @reactive.Effect
-    @reactive.event(input.fields_to_display)
-    def ensure_received_date_selected():
-        selected = list(input.fields_to_display())
-        if "Received Date" not in selected:
-            selected.append("Received Date")
-            ui.update_checkbox_group("fields_to_display", selected=selected)
-
-    # If changing the column selection manually, make sure preset radio buttons updates as well
-    @reactive.Effect
-    @reactive.event(input.fields_to_display)
-    def switch_to_custom_preset():
-        current_selected_fields = set(input.fields_to_display())
-        all_fields = set(samples_df.columns.tolist())
-        preset_all = all_fields
-        preset_no_ids_labels_billing = {x for x in samples_df.columns if x not in ["Reagent Label", "nd_limsid", "qubit_limsid", "prep_limsid", "seq_limsid", "billed_limsid", "Increased Pooling (%)", "Billing Description", "Price"]}
-        preset_billing_info_only = {"Received Date", "LIMSID", "Name", "billed_limsid", "Invoice ID"}
-
-        if current_selected_fields == preset_all:
-            ui.update_radio_buttons("presets", selected="All")
-        elif current_selected_fields == preset_no_ids_labels_billing:
-            ui.update_radio_buttons("presets", selected="All (-IDs,Labels & billinginfo)")
-        elif current_selected_fields == preset_billing_info_only:
-            ui.update_radio_buttons("presets", selected="Billing info only")
-        else:
-            ui.update_radio_buttons("presets", selected="Custom")
-
-    # Update the column selection according to selected radio button preset
-    @reactive.Effect
-    @reactive.event(input.presets)
-    def update_fields_to_display():
-        selected_preset = input.presets()
-        selected_columns = get_selected_columns(selected_preset, list(input.fields_to_display()), samples_df.columns.tolist())
-        ui.update_checkbox_group("fields_to_display", selected=selected_columns)
-    
-    # Set default date range when the app starts
-    @reactive.Effect
-    def set_default_date_range():
-        ui.update_date_range(
-            "date_range",
-            start=pd.to_datetime(samples_df['Received Date']).min().date(),
-            end=datetime.date.today()
-        )
-    
-    # Update date range to default when pressing the reset-button
-    @reactive.Effect
-    @reactive.event(input.reset_date)
-    def reset_date_range():
-        ui.update_date_range(
-            "date_range",
-            start=pd.to_datetime(samples_df['Received Date']).min().date(),
-            end=datetime.date.today()
-        )
-
-    # Render title on filter accordian
-    @render.text
-    def filters_title():
-        start_date, end_date = input.date_range()
-        project_account = input.filter_project_account()
-        experiment_name = input.filter_experiment_name()
-        progress = input.filter_progress()
-        sample_type = input.filter_sample_type()
-
-        num_filters = 0
-        if start_date != pd.to_datetime(samples_df['Received Date']).min().date() or end_date != datetime.date.today():
-            num_filters += 1
-        if project_account:
-            num_filters += 1
-        if experiment_name:
-            num_filters += 1
-        if progress:
-            num_filters += 1
-        if sample_type:
-            num_filters += 1
-
-        total_entries = len(samples_df)
-        filtered_entries = len(filtered_data())
-        filtered_out = total_entries - filtered_entries
-        
-        if num_filters > 0:
-            return f'Filters ({num_filters} filters applied, {filtered_entries} of {total_entries} samples)'
-        else:
-            return f"Filters (All {total_entries} samples shown)"
-    
-    # Render title on column selection accordian
-    @render.text
-    def column_selection_title():
-        selected_columns = list(input.fields_to_display())
-        total_columns = len(samples_df.columns)
-        num_selected = len(selected_columns)
-        return f"Column Selection ({num_selected} of {total_columns} columns selected)"
-
-    @render.ui
-    def samples_info():
-        text = f"<h3>SQL database is updated using these scripts:</h3> \
-        <a href='https://github.com/NorwegianVeterinaryInstitute/nvi_lims_epps/blob/main/shiny_app/update_sqlite.py'>update_sqlite.py (link)</a>\
-        <a href='https://github.com/NorwegianVeterinaryInstitute/nvi_lims_epps/blob/main/shiny_app/update_sqlite_ilmn_seq.py'>update_sqlite_ilmn_seq.py (link)</a> <br>\
-        <h3>Data fields collection </h3> \
-        <p><strong>Extraction step</strong>: Extraction Number</p> \
-        <p><strong>Fluorescence step</strong>: Absorbance, A260/280 ratio, A260/230 ratio, Fluorescence, Storage Box Name, Storage Well</p> \
-        <p><strong>Prep Step</strong>: Experiment Name, Reagent Labels</p> \
-        <p><strong>Billing Step</strong>: Invoice ID, Price, Billing Description</p> <br> \
-        Note that the step must be completed in lims before the data fields are updated in the Shiny App <br>\
-        <h3>Last update to the database (on the clarity server)</h3>\
-        {(datetime.datetime.fromisoformat(samples_date_created).astimezone(pytz.timezone('Europe/Berlin'))).strftime('%Y-%m-%d (kl %H:%M)')} \
-        <br> \
-        <p>NOTE: The database on the LIMS server is updated every full hour and synced to the app every 30 minutes past the hour</p> "
-
-        return ui.HTML(text)
+                            {"className": "dt-center", "targets": "_all"},
+                            {"width": "200px", "targets": "_all"},  # Set a default width for all columns
+                            
+                            # Explicitly define the Received Date column as a date type for searchBuilder
+                            {
+                                "targets": date_column_index,
+                                "type": "date",
+                                "render": JavascriptFunction("""
+                                function(data, type, row) {
+                                    // For sorting and filtering
+                                    if (type === 'sort' || type === 'type' || type === 'filter') {
+                                        if (!data || data === '') {
+                                            return null;
+                                        }
+                                        return data;
+                                    }
+                                    // For display
+                                    return data;
+                                }
+                                """)
+                            }
+                         ]
+                        )) 
 
     # Define outputs that need to be returned
-
     output.data_samples = data_samples
-    output.filters_title = filters_title
-    output.column_selection_title = column_selection_title
-    output.samples_info = samples_info

--- a/src/shinylims/tables/sequencing.py
+++ b/src/shinylims/tables/sequencing.py
@@ -181,7 +181,8 @@ def seq_server(input, output, session, seq_df, seq_date_created):
         column_index = selected_columns.index(column_to_sort)
 
         return ui.HTML(DT(dat[selected_columns], 
-                          layout={"topEnd": "search"}, 
+                          layout={"topEnd": "search"},
+                          select = True,  
                           column_filters="footer", 
                           search={"smart": True},
                           classes="compact nowrap hover order-column cell-border",  

--- a/src/shinylims/tables/sequencing.py
+++ b/src/shinylims/tables/sequencing.py
@@ -2,328 +2,172 @@
 sequencing.py - table module containing UI and server logic for the Sequencing table tab
 '''
 
-from shiny import render, ui, reactive
-from faicons import icon_svg
+from shiny import render, ui
 from itables.shiny import DT
 import pandas as pd
-import datetime
-import pytz
 from itables.javascript import JavascriptFunction
 
-# UI definition for the Sequencing page
+##############################
+# UI ILMN SEQ TABLE
+##############################
+
 def seq_ui():
     return ui.div(
-        ui.tags.style("""
-            /* Custom styling for the samples nav tabs */
-            #seq_navset .nav-link.active { 
-                font-size: 1.5rem !important; 
-            }
-        """),
-        ui.h2("\u00A0", class_="mb-3 text-center"),
-        ui.navset_tab(
-        ui.nav_panel("Table (Nov 2023 ->)",
-            ui.div(
-                ui.accordion(
-                    ui.accordion_panel(
-                        ui.output_text("filters_title_seq"),  # Filter icon
-                        ui.row(ui.column(3,
-                            ui.input_date_range(
-                                id="date_range_seq", 
-                                label="Date Range",
-                                start=None,
-                                end=None,
-                            ),
-                            ui.input_action_button(
-                                id="reset_date_seq", 
-                                label="Reset Date Filter",
-                            ),),
-                            ui.column(3,
-                                ui.input_selectize(
-                                    id="filter_cassette_seq", 
-                                    label="Casette Type", 
-                                    choices=[],
-                                    multiple=True, 
-                                ),),
-                            ui.column(3,
-                                ui.input_selectize(
-                                    id="filter_reads_seq", 
-                                    label="Read Length", 
-                                    choices=[],
-                                    multiple=True, 
-                                ),),),
-                            value="filters", icon=icon_svg("filter"),
-                    ),
-                    ui.accordion_panel(
-                        ui.output_text("column_selection_title_seq"),  # Dynamic title for Column Selection
-                        ui.div(
-                            ui.div(
-                                ui.div(
-                                    ui.input_checkbox_group(
-                                        id="fields_to_display_seq",
-                                        inline=False,
-                                        label=ui.div("Field Selection", class_="fw-bold"),
-                                        choices=[],
-                                        selected=[]
-                                    ),
-                                ),
-                            )
-                        ),
-                        open=False,
-                        value="column_selection_seq",  # Provide a unique value
-                        icon=icon_svg("table-columns")
-                    ),
-                    class_="mb-3 mt-3", 
-                    open=False,
-                    multiple=False
-                ),
-                class_="mb-3"
-            ),
-            ui.output_ui("data_seq"),
-        ),
-        ui.nav_panel("Plots", ui.code("Plots will be displayed here. Waiting for iTables support for selecting data from the table: https://github.com/mwouts/itables/issues/250")),
-        ui.nav_panel("Info",ui.div(
-            ui.code("NB!! Waiting for instrument integration for getting certain QC values. The data collection cron script will also be rewritten after instrument integration is in order NB!!"),
-            ui.card(ui.output_ui("seqRun_info"),))),
-            id="seq_navset"
-    ))
+        #ui.h2("\u00A0", class_="mb-3 text-center"),
+        ui.output_ui("data_seq")
+    )
+
+##############################
+# SERVER ILMN SEQ TABLE
+##############################
 
 # Server logic for the Sequencing page
 def seq_server(input, output, session, seq_df, seq_date_created):
-    # Define a reactive value to store the filtered dataframe
-    seq_filtered_data = reactive.Value(seq_df)
-
-    # Helper function for safely getting columns with different possible names
-    def get_column_safe(df, column_names, default_value=None):
-        """
-        Safely get a column from a dataframe, trying multiple possible names.
-        Returns default_value if none of the column names exist.
-        """
-        if not isinstance(column_names, list):
-            column_names = [column_names]
-        
-        for col in column_names:
-            if col in df.columns:
-                return df[col]
-        
-        # If we get here, none of the columns exist
-        return pd.Series([default_value] * len(df))
     
-    @reactive.Effect
-    def update_project_account_choices_seq():
-        read_length_column = get_column_safe(seq_df, ['Read Length', 'read_length'])
-        if not read_length_column.empty:
-            unique_read_lengths = sorted(read_length_column.unique().tolist())
-            ui.update_selectize("filter_reads_seq", choices=unique_read_lengths)
-        else:
-            ui.update_selectize("filter_reads_seq", choices=["No Read Length Data"])
-    
-    # Update cassette type filter
-    @reactive.Effect
-    def update_cassette_choices_seq():
-        cassette_column = get_column_safe(seq_df, ['Casette Type', 'casette_type'])
-        if not cassette_column.empty:
-            unique_cassettes = cassette_column.unique().tolist()
-            ui.update_selectize("filter_cassette_seq", choices=unique_cassettes)
-        else:
-            ui.update_selectize("filter_cassette_seq", choices=["No Cassette Type Data"])
-
     # Return HTML tag with DT table element
     @render.ui
     def data_seq():
-        filtered_df = seq_df.copy()
-
-        # Date filter
-        start_date, end_date = input.date_range_seq()
-
-        if start_date is not None and end_date is not None:
-            date_col = 'Seq Date' if 'Seq Date' in filtered_df.columns else 'seq_date'
-            if date_col in filtered_df.columns:
-                # Convert the date column to datetime format first
-                filtered_df[date_col] = pd.to_datetime(filtered_df[date_col], errors='coerce')
+        dat = seq_df.copy().reset_index(drop=True)
+        
+        # Properly format date columns for DataTables
+        if "Seq Date" in dat.columns:
+            # Convert to datetime type first
+            dat["Seq Date"] = pd.to_datetime(dat["Seq Date"], errors='coerce')
             
-                # Now perform the filtering
-                filtered_df = filtered_df[
-                    (filtered_df[date_col].isna()) | 
-                    ((filtered_df[date_col] >= pd.to_datetime(start_date)) & 
-                    (filtered_df[date_col] <= pd.to_datetime(end_date)))
-                ]
-                
-        selected_casette_type = input.filter_cassette_seq()
+            # Format dates as strings in a consistent format for display
+            # Keep NaT values as empty strings
+            dat["Seq Date"] = dat["Seq Date"].apply(
+                lambda x: x.strftime('%Y-%m-%d') if pd.notna(x) else ''
+            )
         
-        if selected_casette_type:
-            filtered_df = filtered_df[filtered_df['Casette Type'].isin(selected_casette_type)]
-        
-        selected_filter_reads_seq = input.filter_reads_seq()
-        if selected_filter_reads_seq:
-            filtered_df = filtered_df[filtered_df['Read Length'].isin(selected_filter_reads_seq)]
-
-        selected_columns = list(input.fields_to_display_seq())
-        dat = filtered_df.reset_index(drop=True)
-        seq_filtered_data.set(filtered_df)
-        
-        if 'Comment' in dat[selected_columns].columns:
-            comment_index = dat[selected_columns].columns.get_loc('Comment')
+        # Determine indices for special column handling
+        if 'Comment' in dat.columns:
+            comment_index = dat.columns.get_loc('Comment')
         else:
             comment_index = "Dummy"
 
-        if 'Run Number' in dat[selected_columns].columns:
-            run_number_index = dat[selected_columns].columns.get_loc('Run Number')
+        if 'Run Number' in dat.columns:
+            run_number_index = dat.columns.get_loc('Run Number')
         else:
             run_number_index = "Dummy"
 
-        if 'Cluster density (K/mm2)' in dat[selected_columns].columns:
-            cluster_density_index = dat[selected_columns].columns.get_loc('Cluster density (K/mm2)')
+        if 'Cluster density (K/mm2)' in dat.columns:
+            cluster_density_index = dat.columns.get_loc('Cluster density (K/mm2)')
         else:
             cluster_density_index = "Dummy"
         
-        #Find index for order column
+        # Find index for order column
         column_to_sort = "Seq Date"
-        column_index = selected_columns.index(column_to_sort)
+        if column_to_sort in dat.columns:
+            column_index = dat.columns.get_loc(column_to_sort)
+            date_column_index = column_index  # Store for columnDefs
+        else:
+            column_index = 0  # Default to first column if Seq Date not found
+            date_column_index = -1  # Indicates no date column found
 
-        return ui.HTML(DT(dat[selected_columns], 
-                          layout={"topEnd": "search"},
-                          select = True,  
+        return ui.HTML(DT(dat, 
+                          layout={"topEnd": "search", "top1": "searchBuilder"},
+                          lengthMenu=[[200, 500, 1000, 2000, -1], [200, 500, 1000, 2000, "All"]],
+                          select=True,  
                           column_filters="footer", 
                           search={"smart": True},
                           classes="compact nowrap hover order-column cell-border",  
                           scrollY="750px",
-                          paging=False,
+                          paging=True,
                           maxBytes=0, 
                           autoWidth=True,
                           keys=True,
-                          buttons=["copyHtml5",
-                                  {"extend": "csvHtml5", "title": "WGS Sample Data"},
-                                  {"extend": "excelHtml5", "title": "WGS Sample Data"},],
+                          buttons=[
+                            {'extend': "spacer",
+                             'style': 'bar',
+                             'text': 'Column Settings'},
+                            # Column visibility toggle
+                            {
+                                "extend": "colvis",
+                                "text": "Selection"
+                            },
+                            {'extend': "spacer"},
+                            # Button to deselect all columns
+                            {
+                                "text": "Deselect All",
+                                "action": JavascriptFunction("""
+                                function(e, dt, node, config) {
+                                    dt.columns().visible(false);
+                                }
+                                """)
+                            },
+                            # Button to select all columns
+                            {
+                                "text": "Select All",
+                                "action": JavascriptFunction("""
+                                function(e, dt, node, config) {
+                                    dt.columns().visible(true);
+                                }
+                                """)
+                            },
+                            {'extend': "spacer",
+                             'style': 'bar',
+                             'text': 'Page Length'},
+                             "pageLength",
+                            {'extend': "spacer",
+                             'style': 'bar',
+                             'text': 'Export'},
+                            # Collection of export options
+                            {
+                                "extend": "collection", 
+                                "text": "Type",
+                                "buttons": [
+                                    # Copy to clipboard
+                                    {
+                                        "extend": "copyHtml5",
+                                        "exportOptions": {"columns": ":visible"},
+                                        "text": "Copy to Clipboard"
+                                    },
+                                    # CSV export with visible columns
+                                    {
+                                        "extend": "csvHtml5", 
+                                        "exportOptions": {"columns": ":visible"},
+                                        "title": "Sequencing Data Export",
+                                        "text": "Export to CSV"
+                                    },
+                                    # Excel export with visible columns
+                                    {
+                                        "extend": "excelHtml5", 
+                                        "exportOptions": {"columns": ":visible"},
+                                        "title": "Sequencing Data Export",
+                                        "text": "Export to Excel"
+                                    }
+                                ]
+                            },
+                            {'extend': "spacer",
+                             'style': 'bar'},
+                          ],
                           order=[[column_index, "desc"]],
                           columnDefs=[
                               {'targets': comment_index, 'className': 'left-column'},
                               {"className": "dt-center", "targets": "_all"},
                               {"targets": run_number_index, "render": JavascriptFunction("function(data, type, row) { return type === 'display' ? Math.round(data).toString() : data; }")},
-                              {"targets": cluster_density_index, "render": JavascriptFunction("function(data, type, row) { return type === 'display' ? Math.round(data).toString() : data; }")}
-                              ]))
-
-    @reactive.Effect
-    def set_default_date_range_seq():
-        try:
-            date_column = get_column_safe(seq_df, ['Seq Date', 'seq_date'])
-            if not date_column.empty:
-                min_date = pd.to_datetime(date_column, errors='coerce').min()
-                if pd.notna(min_date):
-                    start_date = min_date.date()
-                else:
-                    start_date = datetime.date(2023, 1, 1)  # Fallback
-            else:
-                start_date = datetime.date(2023, 1, 1)  # Fallback
-        
-            ui.update_date_range(
-                "date_range_seq",
-                start=start_date,
-                end=datetime.date.today()
-            )
-        except Exception as e:
-            print(f"Error setting default date range for sequencing: {e}")
-            ui.update_date_range(
-                "date_range_seq",
-                start=datetime.date(2023, 1, 1),
-                end=datetime.date.today()
-            )
+                              {"targets": cluster_density_index, "render": JavascriptFunction("function(data, type, row) { return type === 'display' ? Math.round(data).toString() : data; }")},
+                              # Explicitly define the Seq Date column as a date type for searchBuilder
+                              {
+                                  "targets": date_column_index,
+                                  "type": "date",
+                                  "render": JavascriptFunction("""
+                                  function(data, type, row) {
+                                      // For sorting and filtering
+                                      if (type === 'sort' || type === 'type' || type === 'filter') {
+                                          if (!data || data === '') {
+                                              return null;
+                                          }
+                                          return data;
+                                      }
+                                      // For display
+                                      return data;
+                                  }
+                                  """)
+                              }
+                          ]))
     
-    # Define default column checkbox selection
-    @reactive.Effect
-    def set_default_fields_to_display_seq():
-        ui.update_checkbox_group(
-            "fields_to_display_seq",
-            choices=seq_df.columns.tolist(),
-            selected=seq_df.columns.tolist()
-        )
-
-    # Reset date filter to default with action button
-    @reactive.Effect
-    @reactive.event(input.reset_date_seq)
-    def reset_date_range_seq():
-        try:
-            date_column = get_column_safe(seq_df, ['Seq Date', 'seq_date'])
-            if not date_column.empty:
-                min_date = pd.to_datetime(date_column, errors='coerce').min()
-                if pd.notna(min_date):
-                    start_date = min_date.date()
-                else:
-                    start_date = datetime.date(2023, 1, 1)  # Fallback
-            else:
-                start_date = datetime.date(2023, 1, 1)  # Fallback
-                
-            ui.update_date_range(
-                "date_range_seq",
-                start=start_date,
-                end=datetime.date.today()
-            )
-        except Exception as e:
-            print(f"Error resetting date range for sequencing: {e}")
-            ui.update_date_range(
-                "date_range_seq",
-                start=datetime.date(2023, 1, 1),
-                end=datetime.date.today()
-            )
-
-    # Render title on filter accordian
-    @render.text
-    def filters_title_seq():
-        start_date, end_date = input.date_range_seq()
-        casette = input.filter_cassette_seq()
-        reads = input.filter_reads_seq()
-
-        num_filters = 0
-        try:
-            date_column = get_column_safe(seq_df, ['Seq Date', 'seq_date'])
-            if not date_column.empty:
-                min_date = pd.to_datetime(date_column, errors='coerce').min()
-                if pd.notna(min_date) and (start_date != min_date.date() or end_date != datetime.date.today()):
-                    num_filters += 1
-        except:
-            pass
-            
-        if casette:
-            num_filters += 1
-        if reads:
-            num_filters += 1
-
-        total_entries = len(seq_df)
-        filtered_entries = len(seq_filtered_data())
-        
-        if num_filters > 0:
-            return f'Filters ({num_filters} filters applied, {filtered_entries} of {total_entries} sequencing runs)'
-        else:
-            return f"Filters (All {total_entries} sequencing runs shown)"
-    
-    # Render title on column selection accordian
-    @render.text
-    def column_selection_title_seq():
-        selected_columns = list(input.fields_to_display_seq())
-        total_columns = len(seq_df.columns)
-        num_selected = len(selected_columns)
-        return f"Column Selection ({num_selected} of {total_columns} columns selected)"
-    
-    
-    @render.ui
-    def seqRun_info():
-        text = f"<h3>SQL database is updated using these scripts:</h3> \
-        <a href='https://github.com/NorwegianVeterinaryInstitute/nvi_lims_epps/blob/main/shiny_app/update_sqlite.py'>update_sqlite.py (link)</a>\
-        <a href='https://github.com/NorwegianVeterinaryInstitute/nvi_lims_epps/blob/main/shiny_app/update_sqlite_ilmn_seq.py'>update_sqlite_ilmn_seq.py (link)</a> <br>\
-        <h3>Data fields collection </h3> \
-        <p>This table is created by using the sequencing steps as starting point and traversing back to step 7 (Generate SampleSheet) and step 6 (Make Final Loading Dilution) to retrieve data</p> \
-        <p><strong>Step 8 (NS/MS Run):</strong> Technician Name, Species, Experiment Name, Comment, Run ID, Flow Cell ID, Reagent Cartridge ID, Date </p>\
-        <p><strong>Step 7 (Generate SampleSheet):</strong> Read 1 Cycles, Read 2 Cycles, Index Cycles </p>\
-        <p><strong>Step 6 (Make Final Loading Dilution):</strong> Final Library Loading (pM), Volume 20pM Denat Sample (µl), PhiX / library spike-in (%), Average Size - bp  </p>\
-        <p>Table will not be updated until the sequencing step has been completed<p>\
-        <h3>Last update to the database (on the clarity server)</h3>\
-        {(datetime.datetime.fromisoformat(seq_date_created).astimezone(pytz.timezone('Europe/Berlin'))).strftime('%Y-%m-%d (kl %H:%M)')} \
-        <br> \
-        <p>NOTE: The database on the LIMS server is updated every full hour and synced to the app every 30 minutes past the hour</p> "
-
-        return ui.HTML(text)
 
     # Define outputs that need to be returned
     output.data_seq = data_seq
-    output.filters_title_seq = filters_title_seq
-    output.column_selection_title_seq = column_selection_title_seq
-    output.seqRun_info = seqRun_info

--- a/uv.lock
+++ b/uv.lock
@@ -1,10 +1,11 @@
 version = 1
+revision = 1
 requires-python = ">=3.11.5"
 resolution-markers = [
-    "python_full_version < '3.12' and platform_system != 'Emscripten'",
-    "python_full_version < '3.12' and platform_system == 'Emscripten'",
-    "python_full_version >= '3.12' and platform_system != 'Emscripten'",
-    "python_full_version >= '3.12' and platform_system == 'Emscripten'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and sys_platform != 'emscripten'",
+    "python_full_version >= '3.12' and sys_platform == 'emscripten'",
 ]
 
 [[package]]
@@ -118,7 +119,7 @@ name = "click"
 version = "8.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
 wheels = [
@@ -345,16 +346,16 @@ wheels = [
 
 [[package]]
 name = "itables"
-version = "2.0.1"
+version = "2.2.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ipython" },
     { name = "numpy" },
     { name = "pandas" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/70/cacc01bb6895c6a5c6db8f05dbbbea1fbf9355c92d8cdd94c01209f1c832/itables-2.0.1.tar.gz", hash = "sha256:dae51872275f7d2a7be7159c280a67ae369ec31bb0d3b87042c5919f6de201a3", size = 1081795 }
+sdist = { url = "https://files.pythonhosted.org/packages/07/18/359fc46f2874290843a4ba2c089d0109874cd2d73863d0e69fd54a5e9532/itables-2.2.5.tar.gz", hash = "sha256:838ed4783da0b6481b9062c362b8a331aa56f48d6c90e0f6dc76a0488a316049", size = 2436699 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/a8/589e34340f3631d73365c98c2027d177e1d9b10c15bb6823283dce690287/itables-2.0.1-py3-none-any.whl", hash = "sha256:ab99561f088eb7dbfca6f24f894a80929fd8c3198f55126441057366e0718bec", size = 221658 },
+    { url = "https://files.pythonhosted.org/packages/aa/dd/8976761076632f492f0d25502e348f41f343423d36270dc32f323b9155bc/itables-2.2.5-py3-none-any.whl", hash = "sha256:d0d33ce427c6c84d4063998650323eb65ccddb47a5505ef1ad3f563580dc101d", size = 1407043 },
 ]
 
 [[package]]
@@ -895,7 +896,7 @@ name = "questionary"
 version = "2.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "prompt-toolkit", marker = "platform_system != 'Emscripten'" },
+    { name = "prompt-toolkit", marker = "sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/84/d0/d73525aeba800df7030ac187d09c59dc40df1c878b4fab8669bdc805535d/questionary-2.0.1.tar.gz", hash = "sha256:bcce898bf3dbb446ff62830c86c5c6fb9a22a54146f0f5597d3da43b10d8fc8b", size = 24726 }
 wheels = [
@@ -938,18 +939,18 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "appdirs" },
     { name = "asgiref" },
-    { name = "click", marker = "platform_system != 'Emscripten'" },
+    { name = "click", marker = "sys_platform != 'emscripten'" },
     { name = "htmltools" },
     { name = "linkify-it-py" },
     { name = "markdown-it-py" },
     { name = "mdit-py-plugins" },
     { name = "packaging" },
     { name = "python-multipart" },
-    { name = "questionary", marker = "platform_system != 'Emscripten'" },
+    { name = "questionary", marker = "sys_platform != 'emscripten'" },
     { name = "starlette" },
     { name = "typing-extensions" },
-    { name = "uvicorn", marker = "platform_system != 'Emscripten'" },
-    { name = "watchfiles", marker = "platform_system != 'Emscripten'" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+    { name = "watchfiles", marker = "sys_platform != 'emscripten'" },
     { name = "websockets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/da/99755041e436ae7385018afcce0275ff35367ab9e70a49f6877ace203647/shiny-0.9.0.tar.gz", hash = "sha256:add19daeb6d5a43f4f60fbc89affed05f4f4b19ffc7ee252001288aa1724ccf9", size = 3618587 }
@@ -975,7 +976,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "faicons", specifier = "==0.2.2" },
-    { name = "itables", specifier = "==2.0.1" },
+    { name = "itables", specifier = "==2.2.5" },
     { name = "pandas", specifier = "==2.2.2" },
     { name = "pins", specifier = "==0.8.5" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
@@ -1093,8 +1094,8 @@ name = "uvicorn"
 version = "0.32.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "platform_system != 'Emscripten'" },
-    { name = "h11", marker = "platform_system != 'Emscripten'" },
+    { name = "click", marker = "sys_platform != 'emscripten'" },
+    { name = "h11", marker = "sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e0/fc/1d785078eefd6945f3e5bab5c076e4230698046231eb0f3747bc5c8fa992/uvicorn-0.32.0.tar.gz", hash = "sha256:f78b36b143c16f54ccdb8190d0a26b5f1901fe5a3c777e1ab29f26391af8551e", size = 77564 }
 wheels = [
@@ -1106,7 +1107,7 @@ name = "watchfiles"
 version = "0.24.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "platform_system != 'Emscripten'" },
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c8/27/2ba23c8cc85796e2d41976439b08d52f691655fdb9401362099502d1f0cf/watchfiles-0.24.0.tar.gz", hash = "sha256:afb72325b74fa7a428c009c1b8be4b4d7c2afedafb2982827ef2156646df2fe1", size = 37870 }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -22,6 +22,20 @@ wheels = [
 ]
 
 [[package]]
+name = "anywidget"
+version = "0.9.16"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ipywidgets" },
+    { name = "psygnal" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/b0/c1871c3296b6c35c2864fdff37a3245d0abc83120b5732476d0aa813e2da/anywidget-0.9.16.tar.gz", hash = "sha256:4d741f67a3d0a5b8e49f345f1bb2fe8fe13a53b379c0896059be6bc85a094950", size = 9796916 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/df/49e9f3f3d610dd1d3b7c0cee5800bf0564cb29250f8755f1aa1a55e7efba/anywidget-0.9.16-py3-none-any.whl", hash = "sha256:1d68567688335200f6730d7c29836f202bf0908f31acb3ef41077f6819f30fc6", size = 220800 },
+]
+
+[[package]]
 name = "appdirs"
 version = "1.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -133,6 +147,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+]
+
+[[package]]
+name = "comm"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/a8/fb783cb0abe2b5fded9f55e5703015cdf1c9c85b3669087c538dd15a6a86/comm-0.2.2.tar.gz", hash = "sha256:3fd7a84065306e07bea1773df6eb8282de51ba82f77c72f9c85716ab11fe980e", size = 6210 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/75/49e5bfe642f71f272236b5b2d2691cf915a7283cc0ceda56357b61daa538/comm-0.2.2-py3-none-any.whl", hash = "sha256:e6fb86cb70ff661ee8c9c14e7d36d6de3b4066f1441be4063df9c5009f0a64d3", size = 7180 },
 ]
 
 [[package]]
@@ -274,15 +300,15 @@ wheels = [
 
 [[package]]
 name = "htmltools"
-version = "0.5.3"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/32/8c37e8884fa7b125b1e3dbce8446786992a8e631f51ef7d58d71408bd04a/htmltools-0.5.3.tar.gz", hash = "sha256:192e430498e8792831cd6cc5d7a43d3f13d8eb03eb7dd7d8e99f629bf73cf03c", size = 93136 }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/1d/c568d17e9fb5ad5aa0ca3531c58d36fe69deb8eee4e53ff6425c1f99f210/htmltools-0.6.0.tar.gz", hash = "sha256:e8a3fb023d748935035db7ff17f620612ffc814a6a80b6ae388f7b7ab182adf7", size = 97152 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/01/34e35d568fcc286db72c89490289dce56fc5892506d37ffa7b3c6e1b2f7e/htmltools-0.5.3-py3-none-any.whl", hash = "sha256:5e2d12309fd6d9eb39a5fe8183da9ad90f6677d73dd41a82ded4b81ba0e43c86", size = 83204 },
+    { url = "https://files.pythonhosted.org/packages/0a/ba/aa99706246f1938ca905eb6eeb7db832ac2e157aa4b805acb5cd4cd1791a/htmltools-0.6.0-py3-none-any.whl", hash = "sha256:072a274ff5e2851e0acce13fc5bb2bbdbbad8268dc8b123f881c05012ce7dce0", size = 84954 },
 ]
 
 [[package]]
@@ -345,6 +371,22 @@ wheels = [
 ]
 
 [[package]]
+name = "ipywidgets"
+version = "8.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "comm" },
+    { name = "ipython" },
+    { name = "jupyterlab-widgets" },
+    { name = "traitlets" },
+    { name = "widgetsnbextension" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/4c/dab2a281b07596a5fc220d49827fe6c794c66f1493d7a74f1df0640f2cc5/ipywidgets-8.1.5.tar.gz", hash = "sha256:870e43b1a35656a80c18c9503bbf2d16802db1cb487eec6fab27d683381dde17", size = 116723 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/2d/9c0b76f2f9cc0ebede1b9371b6f317243028ed60b90705863d493bae622e/ipywidgets-8.1.5-py3-none-any.whl", hash = "sha256:3290f526f87ae6e77655555baba4f36681c555b8bdbbff430b70e52c34c86245", size = 139767 },
+]
+
+[[package]]
 name = "itables"
 version = "2.2.5"
 source = { registry = "https://pypi.org/simple" }
@@ -389,6 +431,29 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/64/33/60135848598c076ce4b231e1b1895170f45fbcaeaa2c9d5e38b04db70c35/joblib-1.4.2.tar.gz", hash = "sha256:2382c5816b2636fbd20a09e0f4e9dad4736765fdfb7dca582943b9c1366b3f0e", size = 2116621 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/91/29/df4b9b42f2be0b623cbd5e2140cafcaa2bef0759a00b7b70104dcfe2fb51/joblib-1.4.2-py3-none-any.whl", hash = "sha256:06d478d5674cbc267e7496a410ee875abd68e4340feff4490bcb7afb88060ae6", size = 301817 },
+]
+
+[[package]]
+name = "jupyter-core"
+version = "5.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "pywin32", marker = "platform_python_implementation != 'PyPy' and sys_platform == 'win32'" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/11/b56381fa6c3f4cc5d2cf54a7dbf98ad9aa0b339ef7a601d6053538b079a7/jupyter_core-5.7.2.tar.gz", hash = "sha256:aa5f8d32bbf6b431ac830496da7392035d6f61b4f54872f15c4bd2a9c3f536d9", size = 87629 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/fb/108ecd1fe961941959ad0ee4e12ee7b8b1477247f30b1fdfd83ceaf017f0/jupyter_core-5.7.2-py3-none-any.whl", hash = "sha256:4f7315d2f6b4bcf2e3e7cb6e46772eba760ae459cd1f59d29eb57b0a01bd7409", size = 28965 },
+]
+
+[[package]]
+name = "jupyterlab-widgets"
+version = "3.0.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/73/fa26bbb747a9ea4fca6b01453aa22990d52ab62dd61384f1ac0dc9d4e7ba/jupyterlab_widgets-3.0.13.tar.gz", hash = "sha256:a2966d385328c1942b683a8cd96b89b8dd82c8b8f81dda902bb2bc06d46f5bed", size = 203556 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/93/858e87edc634d628e5d752ba944c2833133a28fa87bb093e6832ced36a3e/jupyterlab_widgets-3.0.13-py3-none-any.whl", hash = "sha256:e3cda2c233ce144192f1e29914ad522b2f4c40e77214b0cc97377ca3d323db54", size = 214392 },
 ]
 
 [[package]]
@@ -595,6 +660,15 @@ wheels = [
 ]
 
 [[package]]
+name = "narwhals"
+version = "1.31.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/fa/c2b6a4d5dbc4af15aa58c86920d5275a9c65142318179b246685069f57da/narwhals-1.31.0.tar.gz", hash = "sha256:333472e2562343dfdd27407ec9b5114a07c81d0416794e4ac6b703dd925c6a1a", size = 253463 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/c0/fb39bd876ea2fd9509343d643690cd2f9715e6a77271e7c7b26f1eea70c1/narwhals-1.31.0-py3-none-any.whl", hash = "sha256:2a7b79bb5f511055c4c0142121fc0d4171ea171458e12d44dbd9c8fc6488e997", size = 313124 },
+]
+
+[[package]]
 name = "numpy"
 version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -638,6 +712,53 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7c/8e/fc1fdd83a55476765329ac2913321c4aed5b082a7915095628c4ca30ea72/numpy-2.1.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:13311c2db4c5f7609b462bc0f43d3c465424d25c626d95040f073e30f7570e35", size = 16021174 },
     { url = "https://files.pythonhosted.org/packages/2a/b6/a790742aa88067adb4bd6c89a946778c1417d4deaeafce3ca928f26d4c52/numpy-2.1.2-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:2abbf905a0b568706391ec6fa15161fad0fb5d8b68d73c461b3c1bab6064dd62", size = 16400117 },
     { url = "https://files.pythonhosted.org/packages/48/6f/129e3c17e3befe7fefdeaa6890f4c4df3f3cf0831aa053802c3862da67aa/numpy-2.1.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ef444c57d664d35cac4e18c298c47d7b504c66b17c2ea91312e979fcfbdfb08a", size = 14066202 },
+]
+
+[[package]]
+name = "orjson"
+version = "3.10.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/f9/5dea21763eeff8c1590076918a446ea3d6140743e0e36f58f369928ed0f4/orjson-3.10.15.tar.gz", hash = "sha256:05ca7fe452a2e9d8d9d706a2984c95b9c2ebc5db417ce0b7a49b91d50642a23e", size = 5282482 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/a2/21b25ce4a2c71dbb90948ee81bd7a42b4fbfc63162e57faf83157d5540ae/orjson-3.10.15-cp311-cp311-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:c4cc83960ab79a4031f3119cc4b1a1c627a3dc09df125b27c4201dff2af7eaa6", size = 249533 },
+    { url = "https://files.pythonhosted.org/packages/b2/85/2076fc12d8225698a51278009726750c9c65c846eda741e77e1761cfef33/orjson-3.10.15-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ddbeef2481d895ab8be5185f2432c334d6dec1f5d1933a9c83014d188e102cef", size = 125230 },
+    { url = "https://files.pythonhosted.org/packages/06/df/a85a7955f11274191eccf559e8481b2be74a7c6d43075d0a9506aa80284d/orjson-3.10.15-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9e590a0477b23ecd5b0ac865b1b907b01b3c5535f5e8a8f6ab0e503efb896334", size = 150148 },
+    { url = "https://files.pythonhosted.org/packages/37/b3/94c55625a29b8767c0eed194cb000b3787e3c23b4cdd13be17bae6ccbb4b/orjson-3.10.15-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a6be38bd103d2fd9bdfa31c2720b23b5d47c6796bcb1d1b598e3924441b4298d", size = 139749 },
+    { url = "https://files.pythonhosted.org/packages/53/ba/c608b1e719971e8ddac2379f290404c2e914cf8e976369bae3cad88768b1/orjson-3.10.15-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ff4f6edb1578960ed628a3b998fa54d78d9bb3e2eb2cfc5c2a09732431c678d0", size = 154558 },
+    { url = "https://files.pythonhosted.org/packages/b2/c4/c1fb835bb23ad788a39aa9ebb8821d51b1c03588d9a9e4ca7de5b354fdd5/orjson-3.10.15-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b0482b21d0462eddd67e7fce10b89e0b6ac56570424662b685a0d6fccf581e13", size = 130349 },
+    { url = "https://files.pythonhosted.org/packages/78/14/bb2b48b26ab3c570b284eb2157d98c1ef331a8397f6c8bd983b270467f5c/orjson-3.10.15-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:bb5cc3527036ae3d98b65e37b7986a918955f85332c1ee07f9d3f82f3a6899b5", size = 138513 },
+    { url = "https://files.pythonhosted.org/packages/4a/97/d5b353a5fe532e92c46467aa37e637f81af8468aa894cd77d2ec8a12f99e/orjson-3.10.15-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d569c1c462912acdd119ccbf719cf7102ea2c67dd03b99edcb1a3048651ac96b", size = 130942 },
+    { url = "https://files.pythonhosted.org/packages/b5/5d/a067bec55293cca48fea8b9928cfa84c623be0cce8141d47690e64a6ca12/orjson-3.10.15-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:1e6d33efab6b71d67f22bf2962895d3dc6f82a6273a965fab762e64fa90dc399", size = 414717 },
+    { url = "https://files.pythonhosted.org/packages/6f/9a/1485b8b05c6b4c4db172c438cf5db5dcfd10e72a9bc23c151a1137e763e0/orjson-3.10.15-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:c33be3795e299f565681d69852ac8c1bc5c84863c0b0030b2b3468843be90388", size = 141033 },
+    { url = "https://files.pythonhosted.org/packages/f8/d2/fc67523656e43a0c7eaeae9007c8b02e86076b15d591e9be11554d3d3138/orjson-3.10.15-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:eea80037b9fae5339b214f59308ef0589fc06dc870578b7cce6d71eb2096764c", size = 129720 },
+    { url = "https://files.pythonhosted.org/packages/79/42/f58c7bd4e5b54da2ce2ef0331a39ccbbaa7699b7f70206fbf06737c9ed7d/orjson-3.10.15-cp311-cp311-win32.whl", hash = "sha256:d5ac11b659fd798228a7adba3e37c010e0152b78b1982897020a8e019a94882e", size = 142473 },
+    { url = "https://files.pythonhosted.org/packages/00/f8/bb60a4644287a544ec81df1699d5b965776bc9848d9029d9f9b3402ac8bb/orjson-3.10.15-cp311-cp311-win_amd64.whl", hash = "sha256:cf45e0214c593660339ef63e875f32ddd5aa3b4adc15e662cdb80dc49e194f8e", size = 133570 },
+    { url = "https://files.pythonhosted.org/packages/66/85/22fe737188905a71afcc4bf7cc4c79cd7f5bbe9ed1fe0aac4ce4c33edc30/orjson-3.10.15-cp312-cp312-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:9d11c0714fc85bfcf36ada1179400862da3288fc785c30e8297844c867d7505a", size = 249504 },
+    { url = "https://files.pythonhosted.org/packages/48/b7/2622b29f3afebe938a0a9037e184660379797d5fd5234e5998345d7a5b43/orjson-3.10.15-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dba5a1e85d554e3897fa9fe6fbcff2ed32d55008973ec9a2b992bd9a65d2352d", size = 125080 },
+    { url = "https://files.pythonhosted.org/packages/ce/8f/0b72a48f4403d0b88b2a41450c535b3e8989e8a2d7800659a967efc7c115/orjson-3.10.15-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7723ad949a0ea502df656948ddd8b392780a5beaa4c3b5f97e525191b102fff0", size = 150121 },
+    { url = "https://files.pythonhosted.org/packages/06/ec/acb1a20cd49edb2000be5a0404cd43e3c8aad219f376ac8c60b870518c03/orjson-3.10.15-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6fd9bc64421e9fe9bd88039e7ce8e58d4fead67ca88e3a4014b143cec7684fd4", size = 139796 },
+    { url = "https://files.pythonhosted.org/packages/33/e1/f7840a2ea852114b23a52a1c0b2bea0a1ea22236efbcdb876402d799c423/orjson-3.10.15-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dadba0e7b6594216c214ef7894c4bd5f08d7c0135f4dd0145600be4fbcc16767", size = 154636 },
+    { url = "https://files.pythonhosted.org/packages/fa/da/31543337febd043b8fa80a3b67de627669b88c7b128d9ad4cc2ece005b7a/orjson-3.10.15-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b48f59114fe318f33bbaee8ebeda696d8ccc94c9e90bc27dbe72153094e26f41", size = 130621 },
+    { url = "https://files.pythonhosted.org/packages/ed/78/66115dc9afbc22496530d2139f2f4455698be444c7c2475cb48f657cefc9/orjson-3.10.15-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:035fb83585e0f15e076759b6fedaf0abb460d1765b6a36f48018a52858443514", size = 138516 },
+    { url = "https://files.pythonhosted.org/packages/22/84/cd4f5fb5427ffcf823140957a47503076184cb1ce15bcc1165125c26c46c/orjson-3.10.15-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d13b7fe322d75bf84464b075eafd8e7dd9eae05649aa2a5354cfa32f43c59f17", size = 130762 },
+    { url = "https://files.pythonhosted.org/packages/93/1f/67596b711ba9f56dd75d73b60089c5c92057f1130bb3a25a0f53fb9a583b/orjson-3.10.15-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:7066b74f9f259849629e0d04db6609db4cf5b973248f455ba5d3bd58a4daaa5b", size = 414700 },
+    { url = "https://files.pythonhosted.org/packages/7c/0c/6a3b3271b46443d90efb713c3e4fe83fa8cd71cda0d11a0f69a03f437c6e/orjson-3.10.15-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:88dc3f65a026bd3175eb157fea994fca6ac7c4c8579fc5a86fc2114ad05705b7", size = 141077 },
+    { url = "https://files.pythonhosted.org/packages/3b/9b/33c58e0bfc788995eccd0d525ecd6b84b40d7ed182dd0751cd4c1322ac62/orjson-3.10.15-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b342567e5465bd99faa559507fe45e33fc76b9fb868a63f1642c6bc0735ad02a", size = 129898 },
+    { url = "https://files.pythonhosted.org/packages/01/c1/d577ecd2e9fa393366a1ea0a9267f6510d86e6c4bb1cdfb9877104cac44c/orjson-3.10.15-cp312-cp312-win32.whl", hash = "sha256:0a4f27ea5617828e6b58922fdbec67b0aa4bb844e2d363b9244c47fa2180e665", size = 142566 },
+    { url = "https://files.pythonhosted.org/packages/ed/eb/a85317ee1732d1034b92d56f89f1de4d7bf7904f5c8fb9dcdd5b1c83917f/orjson-3.10.15-cp312-cp312-win_amd64.whl", hash = "sha256:ef5b87e7aa9545ddadd2309efe6824bd3dd64ac101c15dae0f2f597911d46eaa", size = 133732 },
+    { url = "https://files.pythonhosted.org/packages/06/10/fe7d60b8da538e8d3d3721f08c1b7bff0491e8fa4dd3bf11a17e34f4730e/orjson-3.10.15-cp313-cp313-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:bae0e6ec2b7ba6895198cd981b7cca95d1487d0147c8ed751e5632ad16f031a6", size = 249399 },
+    { url = "https://files.pythonhosted.org/packages/6b/83/52c356fd3a61abd829ae7e4366a6fe8e8863c825a60d7ac5156067516edf/orjson-3.10.15-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f93ce145b2db1252dd86af37d4165b6faa83072b46e3995ecc95d4b2301b725a", size = 125044 },
+    { url = "https://files.pythonhosted.org/packages/55/b2/d06d5901408e7ded1a74c7c20d70e3a127057a6d21355f50c90c0f337913/orjson-3.10.15-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7c203f6f969210128af3acae0ef9ea6aab9782939f45f6fe02d05958fe761ef9", size = 150066 },
+    { url = "https://files.pythonhosted.org/packages/75/8c/60c3106e08dc593a861755781c7c675a566445cc39558677d505878d879f/orjson-3.10.15-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8918719572d662e18b8af66aef699d8c21072e54b6c82a3f8f6404c1f5ccd5e0", size = 139737 },
+    { url = "https://files.pythonhosted.org/packages/6a/8c/ae00d7d0ab8a4490b1efeb01ad4ab2f1982e69cc82490bf8093407718ff5/orjson-3.10.15-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f71eae9651465dff70aa80db92586ad5b92df46a9373ee55252109bb6b703307", size = 154804 },
+    { url = "https://files.pythonhosted.org/packages/22/86/65dc69bd88b6dd254535310e97bc518aa50a39ef9c5a2a5d518e7a223710/orjson-3.10.15-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e117eb299a35f2634e25ed120c37c641398826c2f5a3d3cc39f5993b96171b9e", size = 130583 },
+    { url = "https://files.pythonhosted.org/packages/bb/00/6fe01ededb05d52be42fabb13d93a36e51f1fd9be173bd95707d11a8a860/orjson-3.10.15-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:13242f12d295e83c2955756a574ddd6741c81e5b99f2bef8ed8d53e47a01e4b7", size = 138465 },
+    { url = "https://files.pythonhosted.org/packages/db/2f/4cc151c4b471b0cdc8cb29d3eadbce5007eb0475d26fa26ed123dca93b33/orjson-3.10.15-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7946922ada8f3e0b7b958cc3eb22cfcf6c0df83d1fe5521b4a100103e3fa84c8", size = 130742 },
+    { url = "https://files.pythonhosted.org/packages/9f/13/8a6109e4b477c518498ca37963d9c0eb1508b259725553fb53d53b20e2ea/orjson-3.10.15-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:b7155eb1623347f0f22c38c9abdd738b287e39b9982e1da227503387b81b34ca", size = 414669 },
+    { url = "https://files.pythonhosted.org/packages/22/7b/1d229d6d24644ed4d0a803de1b0e2df832032d5beda7346831c78191b5b2/orjson-3.10.15-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:208beedfa807c922da4e81061dafa9c8489c6328934ca2a562efa707e049e561", size = 141043 },
+    { url = "https://files.pythonhosted.org/packages/cc/d3/6dc91156cf12ed86bed383bcb942d84d23304a1e57b7ab030bf60ea130d6/orjson-3.10.15-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eca81f83b1b8c07449e1d6ff7074e82e3fd6777e588f1a6632127f286a968825", size = 129826 },
+    { url = "https://files.pythonhosted.org/packages/b3/38/c47c25b86f6996f1343be721b6ea4367bc1c8bc0fc3f6bbcd995d18cb19d/orjson-3.10.15-cp313-cp313-win32.whl", hash = "sha256:c03cd6eea1bd3b949d0d007c8d57049aa2b39bd49f58b4b2af571a5d3833d890", size = 142542 },
+    { url = "https://files.pythonhosted.org/packages/27/f1/1d7ec15b20f8ce9300bc850de1e059132b88990e46cd0ccac29cbf11e4f9/orjson-3.10.15-cp313-cp313-win_amd64.whl", hash = "sha256:fd56a26a04f6ba5fb2045b0acc487a63162a958ed837648c5781e1fe3316cfbf", size = 133444 },
 ]
 
 [[package]]
@@ -770,6 +891,28 @@ wheels = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.3.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/2d/7d512a3913d60623e7eb945c6d1b4f0bddf1d0b7ada5225274c87e5b53d1/platformdirs-4.3.7.tar.gz", hash = "sha256:eb437d586b6a0986388f0d6f74aa0cde27b48d0e3d66843640bfb6bdcdb6e351", size = 21291 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/45/59578566b3275b8fd9157885918fcd0c4d74162928a5310926887b856a51/platformdirs-4.3.7-py3-none-any.whl", hash = "sha256:a03875334331946f13c549dbd8f4bac7a13a50a895a0eb1e8c6a8ace80d40a94", size = 18499 },
+]
+
+[[package]]
+name = "plotly"
+version = "6.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "narwhals" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/cc/e41b5f697ae403f0b50e47b7af2e36642a193085f553bf7cc1169362873a/plotly-6.0.1.tar.gz", hash = "sha256:dd8400229872b6e3c964b099be699f8d00c489a974f2cfccfad5e8240873366b", size = 8094643 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/65/ad2bc85f7377f5cfba5d4466d5474423a3fb7f6a97fd807c06f92dd3e721/plotly-6.0.1-py3-none-any.whl", hash = "sha256:4714db20fea57a435692c548a4eb4fae454f7daddf15f8d8ba7e1045681d7768", size = 14805757 },
+]
+
+[[package]]
 name = "prompt-toolkit"
 version = "3.0.36"
 source = { registry = "https://pypi.org/simple" }
@@ -779,6 +922,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fb/93/180be2342f89f16543ec4eb3f25083b5b84eba5378f68efff05409fb39a9/prompt_toolkit-3.0.36.tar.gz", hash = "sha256:3e163f254bef5a03b146397d7c1963bd3e2812f0964bb9a24e6ec761fd28db63", size = 423863 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/37/791f1a6edd13c61cac85282368aa68cb0f3f164440fdf60032f2cc6ca34e/prompt_toolkit-3.0.36-py3-none-any.whl", hash = "sha256:aa64ad242a462c5ff0363a7b9cfe696c20d55d9fc60c11fd8e632d064804d305", size = 386414 },
+]
+
+[[package]]
+name = "psygnal"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/7f/ef01fa880529b0cbdf33a02e690cbca7868ee0ee291bcb2ebce53f3b3043/psygnal-0.12.0.tar.gz", hash = "sha256:8d2a99803f3152c469d3642d36c04d680213a20e114245558e026695adf9a9c2", size = 104400 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/57/d6b488dac03f65e731843c984e4677a30c48dd4c5dae3c04df7993ce3168/psygnal-0.12.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2a9ee1e6c441074fe71765b0a96c75b19d72c8198ec5bdea7e97e06a6fe9bd41", size = 458923 },
+    { url = "https://files.pythonhosted.org/packages/7a/fa/bab2170fc8b47a4c591e7ab821fc1fe3d4b10292753f47acba7323eb3d66/psygnal-0.12.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0cdb387d1d6f00649c970a8084e4ae3fcd3e38ac12b5c51d086fc9e01d8f7530", size = 430113 },
+    { url = "https://files.pythonhosted.org/packages/2e/58/91359b72fe0413626be8857122897bb9238fa7b1dd53a3ed299183a17cb6/psygnal-0.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b410dab639353320044856cef68bd9aa940f8e1399da2f57522356b42bc4cf5d", size = 765465 },
+    { url = "https://files.pythonhosted.org/packages/9c/ee/869a2d6741ba3848d6cadf35a1f08535115eab67b7b1c41b2d45f467da7a/psygnal-0.12.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:cd075d7bbe82f0615cfef953ed19ca54feba08f1686b42655c02d6ade0b0beb5", size = 751927 },
+    { url = "https://files.pythonhosted.org/packages/68/eb/c59c13a6da8263f3119a3d9faa7790e58d4fe541458197de4b2370927d52/psygnal-0.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:cc763dbab05fb75f4517c8bd31ede6a4f27e68c59adca55b81a9d7bc875156e0", size = 377665 },
+    { url = "https://files.pythonhosted.org/packages/9b/2e/6cff528f8f5dc7f60221fddca85ed52131a90b606a72c5a4085606d5217d/psygnal-0.12.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:dac134c8890e3d0e413ab701fcb56a882f9b151a6a9d625080736c36833b26ed", size = 469384 },
+    { url = "https://files.pythonhosted.org/packages/55/9d/774d547ed1fcb079de7fc41b1e3103b261eebae7f34da5cf05909a040470/psygnal-0.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bc2324cef7ba3f4d30d32895f8cb7d5cf9ad7bcfdb7955aa92a0fbfe7537ec3f", size = 426617 },
+    { url = "https://files.pythonhosted.org/packages/b4/89/300991108d86c00e6aa84ea85e9c998e27eed59fdcb1abd3e69b9f4d62f5/psygnal-0.12.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ae2bd6edcf911fbff34ed75150e8f8dfb246ebf203514c7c1e4397cabbb1368a", size = 787401 },
+    { url = "https://files.pythonhosted.org/packages/9e/ae/8cc64c0f1eebbc4be74a953e76e431431c770a30f28b71b48edc7f6b8288/psygnal-0.12.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d6fbeee192beab90ca23d9d3ee3bf1eb7ef5f00e815fa53e23e402feee617242", size = 781293 },
+    { url = "https://files.pythonhosted.org/packages/84/09/f00841834b7ae543bd232c22e557914d63d0d0430d32980883421d5981bb/psygnal-0.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:25a9f2db710a6cd2566b3e0e03cf6e04d56276f36ac86b42fa22d81f9a4ac0f2", size = 381816 },
+    { url = "https://files.pythonhosted.org/packages/cb/b4/64a06b1d9b7628c84c9ea68a6cdc9d54378bae04695e7173addb9cf46607/psygnal-0.12.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2f4c1fed9337f57778109c397b6b9591961123ce4bbeb068115c0468964fc2b4", size = 468346 },
+    { url = "https://files.pythonhosted.org/packages/78/be/b3df7dac845f5f6b9897e60d19c3eaed27b56b024099588db92c3b76bb21/psygnal-0.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2d5a953a50fc8263bb23bc558b926cf691f70c9c781c68c64c983fb8cbead910", size = 426482 },
+    { url = "https://files.pythonhosted.org/packages/df/36/0017e838d3c63081a64e6d2252c8dda368a6d0898c7ecf689ba678fe4127/psygnal-0.12.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a67ec8e0c8a6553dd56ed653f87c46ef652b0c512bb8c8f8c5adcff3907751f", size = 785239 },
+    { url = "https://files.pythonhosted.org/packages/67/d0/7057151debcd5c7d8ce7789d276e18681d5c141c9222c9cf99ce3a418680/psygnal-0.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:742abb2d0e230521b208161eeab06abb682a19239e734e543a269214c84a54d2", size = 779690 },
+    { url = "https://files.pythonhosted.org/packages/5e/ae/a3d6815db583b6d05878b3647ea0e2aa21ce6941d03c9d2c6caad1afbcf6/psygnal-0.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:d779f20c6977ec9d5b9fece23b4b28bbcf0a7773539a4a176b5527aea5da27c7", size = 382622 },
+    { url = "https://files.pythonhosted.org/packages/eb/fa/84fc30ad391081cb119099aae5491ba4a9ebd34ce5139bf05b31813abb84/psygnal-0.12.0-py3-none-any.whl", hash = "sha256:15f39abd8bee2926e79da76bec31a258d03dbe3e61d22d6251f65caefbae5d54", size = 78492 },
 ]
 
 [[package]]
@@ -854,6 +1021,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3a/31/3c70bf7603cc2dca0f19bdc53b4537a797747a58875b552c8c413d963a3f/pytz-2024.2.tar.gz", hash = "sha256:2aa355083c50a0f93fa581709deac0c9ad65cca8a9e9beac660adcbd493c798a", size = 319692 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/c3/005fcca25ce078d2cc29fd559379817424e94885510568bc1bc53d7d5846/pytz-2024.2-py2.py3-none-any.whl", hash = "sha256:31c7c1817eb7fae7ca4b8c7ee50c72f93aa2dd863de768e1ef4245d426aa0725", size = 508002 },
+]
+
+[[package]]
+name = "pywin32"
+version = "310"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/b1/68aa2986129fb1011dabbe95f0136f44509afaf072b12b8f815905a39f33/pywin32-310-cp311-cp311-win32.whl", hash = "sha256:1e765f9564e83011a63321bb9d27ec456a0ed90d3732c4b2e312b855365ed8bd", size = 8784284 },
+    { url = "https://files.pythonhosted.org/packages/b3/bd/d1592635992dd8db5bb8ace0551bc3a769de1ac8850200cfa517e72739fb/pywin32-310-cp311-cp311-win_amd64.whl", hash = "sha256:126298077a9d7c95c53823934f000599f66ec9296b09167810eb24875f32689c", size = 9520748 },
+    { url = "https://files.pythonhosted.org/packages/90/b1/ac8b1ffce6603849eb45a91cf126c0fa5431f186c2e768bf56889c46f51c/pywin32-310-cp311-cp311-win_arm64.whl", hash = "sha256:19ec5fc9b1d51c4350be7bb00760ffce46e6c95eaf2f0b2f1150657b1a43c582", size = 8455941 },
+    { url = "https://files.pythonhosted.org/packages/6b/ec/4fdbe47932f671d6e348474ea35ed94227fb5df56a7c30cbbb42cd396ed0/pywin32-310-cp312-cp312-win32.whl", hash = "sha256:8a75a5cc3893e83a108c05d82198880704c44bbaee4d06e442e471d3c9ea4f3d", size = 8796239 },
+    { url = "https://files.pythonhosted.org/packages/e3/e5/b0627f8bb84e06991bea89ad8153a9e50ace40b2e1195d68e9dff6b03d0f/pywin32-310-cp312-cp312-win_amd64.whl", hash = "sha256:bf5c397c9a9a19a6f62f3fb821fbf36cac08f03770056711f765ec1503972060", size = 9503839 },
+    { url = "https://files.pythonhosted.org/packages/1f/32/9ccf53748df72301a89713936645a664ec001abd35ecc8578beda593d37d/pywin32-310-cp312-cp312-win_arm64.whl", hash = "sha256:2349cc906eae872d0663d4d6290d13b90621eaf78964bb1578632ff20e152966", size = 8459470 },
+    { url = "https://files.pythonhosted.org/packages/1c/09/9c1b978ffc4ae53999e89c19c77ba882d9fce476729f23ef55211ea1c034/pywin32-310-cp313-cp313-win32.whl", hash = "sha256:5d241a659c496ada3253cd01cfaa779b048e90ce4b2b38cd44168ad555ce74ab", size = 8794384 },
+    { url = "https://files.pythonhosted.org/packages/45/3c/b4640f740ffebadd5d34df35fecba0e1cfef8fde9f3e594df91c28ad9b50/pywin32-310-cp313-cp313-win_amd64.whl", hash = "sha256:667827eb3a90208ddbdcc9e860c81bde63a135710e21e4cb3348968e4bd5249e", size = 9503039 },
+    { url = "https://files.pythonhosted.org/packages/b4/f4/f785020090fb050e7fb6d34b780f2231f302609dc964672f72bfaeb59a28/pywin32-310-cp313-cp313-win_arm64.whl", hash = "sha256:e308f831de771482b7cf692a1f308f8fca701b2d8f9dde6cc440c7da17e47b33", size = 8458152 },
 ]
 
 [[package]]
@@ -933,8 +1116,17 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "77.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/ed/7101d53811fd359333583330ff976e5177c5e871ca8b909d1d6c30553aa3/setuptools-77.0.3.tar.gz", hash = "sha256:583b361c8da8de57403743e756609670de6fb2345920e36dc5c2d914c319c945", size = 1367236 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/07/99f2cefae815c66eb23148f15d79ec055429c38fa8986edcc712ab5f3223/setuptools-77.0.3-py3-none-any.whl", hash = "sha256:67122e78221da5cf550ddd04cf8742c8fe12094483749a792d56cd669d6cf58c", size = 1255678 },
+]
+
+[[package]]
 name = "shiny"
-version = "0.9.0"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "appdirs" },
@@ -944,33 +1136,40 @@ dependencies = [
     { name = "linkify-it-py" },
     { name = "markdown-it-py" },
     { name = "mdit-py-plugins" },
+    { name = "narwhals" },
+    { name = "orjson" },
     { name = "packaging" },
-    { name = "python-multipart" },
+    { name = "prompt-toolkit", marker = "sys_platform != 'emscripten'" },
+    { name = "python-multipart", marker = "sys_platform != 'emscripten'" },
     { name = "questionary", marker = "sys_platform != 'emscripten'" },
+    { name = "setuptools", marker = "python_full_version >= '3.12'" },
     { name = "starlette" },
     { name = "typing-extensions" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
     { name = "watchfiles", marker = "sys_platform != 'emscripten'" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/76/da/99755041e436ae7385018afcce0275ff35367ab9e70a49f6877ace203647/shiny-0.9.0.tar.gz", hash = "sha256:add19daeb6d5a43f4f60fbc89affed05f4f4b19ffc7ee252001288aa1724ccf9", size = 3618587 }
+sdist = { url = "https://files.pythonhosted.org/packages/41/ff/91e918904bc3502967ca8be684d45825f31ff5e9bc0946e268e9fe8858ba/shiny-1.3.0.tar.gz", hash = "sha256:0e29ccc9b642bf45409efc6a4e9751c29ab9378ac31f1b2f025552ebd7699c99", size = 4996577 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/a2/d00c752eb6c7cd192e06d8614d4a0880caa516a8724a507743229cc99c6a/shiny-0.9.0-py3-none-any.whl", hash = "sha256:2977f595fb6dfe7734678060b6b844ac1fe2701318502d403a89c6250f9847cc", size = 3678964 },
+    { url = "https://files.pythonhosted.org/packages/83/4b/d1cd6e39d06b26de36c03f08f98cac800aa7d240f934d93536afc8d2a054/shiny-1.3.0-py3-none-any.whl", hash = "sha256:c1a524f3512c02072f0fd124f7c13dfe03fe51f24ceda4ce9dab0f755deb891d", size = 3769110 },
 ]
 
 [[package]]
 name = "shinylims-uv"
-version = "0.1.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "faicons" },
     { name = "itables" },
     { name = "pandas" },
     { name = "pins" },
+    { name = "plotly" },
     { name = "python-dotenv" },
     { name = "seaborn" },
     { name = "shiny" },
     { name = "shinyswatch" },
+    { name = "shinywidgets" },
+    { name = "tomli" },
 ]
 
 [package.metadata]
@@ -979,10 +1178,13 @@ requires-dist = [
     { name = "itables", specifier = "==2.2.5" },
     { name = "pandas", specifier = "==2.2.2" },
     { name = "pins", specifier = "==0.8.5" },
+    { name = "plotly", specifier = "==6.0.1" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "seaborn", specifier = "==0.13.2" },
-    { name = "shiny", specifier = "==0.9.0" },
+    { name = "shiny", specifier = "==1.3.0" },
     { name = "shinyswatch", specifier = "==0.6.1" },
+    { name = "shinywidgets", specifier = "==0.5.1" },
+    { name = "tomli", specifier = "==2.2.1" },
 ]
 
 [[package]]
@@ -998,6 +1200,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d8/87/3dc2f847a0e675595d1d9de9364b4bdb2596dcefe5c9d9f61a9427d85959/shinyswatch-0.6.1.tar.gz", hash = "sha256:056417c8405e3dd0927694f1bcaebad1e35992fc443cc7feaa1415afb42a2384", size = 1083767 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/e3/097fbbcf9e1644157056c34936b5c19e982235ed09e2be6c6be1ab5fec57/shinyswatch-0.6.1-py3-none-any.whl", hash = "sha256:176eed49f0f7ebb4a1e83eb9f1b80f6ea56b260d0f95798bc68a02adc68c5277", size = 1102716 },
+]
+
+[[package]]
+name = "shinywidgets"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anywidget" },
+    { name = "ipywidgets" },
+    { name = "jupyter-core" },
+    { name = "python-dateutil" },
+    { name = "shiny" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/67/92c163997bb43bc41a21e9243701809a97eb61a35b9bd7f7c37ba0c80ad5/shinywidgets-0.5.1.tar.gz", hash = "sha256:5307974870b3854352ce6359e20a337d2ba840212edb0ad4114864b1c2eebeb3", size = 1807255 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/ad/f5696c7759291d31c22f03aa5325208961bd23f48a425feb5427699e70ba/shinywidgets-0.5.1-py3-none-any.whl", hash = "sha256:a866e9a7a2b05ded7b637943ea7b7dfd8975a3810dce475242f6d1e913613dd7", size = 1815965 },
 ]
 
 [[package]]
@@ -1042,6 +1260,45 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/78/53/c3a36690a923706e7ac841f649c64f5108889ab1ec44218dac45771f252a/starlette-0.41.0.tar.gz", hash = "sha256:39cbd8768b107d68bfe1ff1672b38a2c38b49777de46d2a592841d58e3bf7c2a", size = 2573755 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/35/c6/a4443bfabf5629129512ca0e07866c4c3c094079ba4e9b2551006927253c/starlette-0.41.0-py3-none-any.whl", hash = "sha256:a0193a3c413ebc9c78bff1c3546a45bb8c8bcb4a84cae8747d650a65bd37210a", size = 73216 },
+]
+
+[[package]]
+name = "tomli"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/87/302344fed471e44a87289cf4967697d07e532f2421fdaf868a303cbae4ff/tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff", size = 17175 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/ca/75707e6efa2b37c77dadb324ae7d9571cb424e61ea73fad7c56c2d14527f/tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249", size = 131077 },
+    { url = "https://files.pythonhosted.org/packages/c7/16/51ae563a8615d472fdbffc43a3f3d46588c264ac4f024f63f01283becfbb/tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6", size = 123429 },
+    { url = "https://files.pythonhosted.org/packages/f1/dd/4f6cd1e7b160041db83c694abc78e100473c15d54620083dbd5aae7b990e/tomli-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a", size = 226067 },
+    { url = "https://files.pythonhosted.org/packages/a9/6b/c54ede5dc70d648cc6361eaf429304b02f2871a345bbdd51e993d6cdf550/tomli-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6972ca9c9cc9f0acaa56a8ca1ff51e7af152a9f87fb64623e31d5c83700080ee", size = 236030 },
+    { url = "https://files.pythonhosted.org/packages/1f/47/999514fa49cfaf7a92c805a86c3c43f4215621855d151b61c602abb38091/tomli-2.2.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c954d2250168d28797dd4e3ac5cf812a406cd5a92674ee4c8f123c889786aa8e", size = 240898 },
+    { url = "https://files.pythonhosted.org/packages/73/41/0a01279a7ae09ee1573b423318e7934674ce06eb33f50936655071d81a24/tomli-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8dd28b3e155b80f4d54beb40a441d366adcfe740969820caf156c019fb5c7ec4", size = 229894 },
+    { url = "https://files.pythonhosted.org/packages/55/18/5d8bc5b0a0362311ce4d18830a5d28943667599a60d20118074ea1b01bb7/tomli-2.2.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e59e304978767a54663af13c07b3d1af22ddee3bb2fb0618ca1593e4f593a106", size = 245319 },
+    { url = "https://files.pythonhosted.org/packages/92/a3/7ade0576d17f3cdf5ff44d61390d4b3febb8a9fc2b480c75c47ea048c646/tomli-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:33580bccab0338d00994d7f16f4c4ec25b776af3ffaac1ed74e0b3fc95e885a8", size = 238273 },
+    { url = "https://files.pythonhosted.org/packages/72/6f/fa64ef058ac1446a1e51110c375339b3ec6be245af9d14c87c4a6412dd32/tomli-2.2.1-cp311-cp311-win32.whl", hash = "sha256:465af0e0875402f1d226519c9904f37254b3045fc5084697cefb9bdde1ff99ff", size = 98310 },
+    { url = "https://files.pythonhosted.org/packages/6a/1c/4a2dcde4a51b81be3530565e92eda625d94dafb46dbeb15069df4caffc34/tomli-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2d0f2fdd22b02c6d81637a3c95f8cd77f995846af7414c5c4b8d0545afa1bc4b", size = 108309 },
+    { url = "https://files.pythonhosted.org/packages/52/e1/f8af4c2fcde17500422858155aeb0d7e93477a0d59a98e56cbfe75070fd0/tomli-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea", size = 132762 },
+    { url = "https://files.pythonhosted.org/packages/03/b8/152c68bb84fc00396b83e7bbddd5ec0bd3dd409db4195e2a9b3e398ad2e3/tomli-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8", size = 123453 },
+    { url = "https://files.pythonhosted.org/packages/c8/d6/fc9267af9166f79ac528ff7e8c55c8181ded34eb4b0e93daa767b8841573/tomli-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192", size = 233486 },
+    { url = "https://files.pythonhosted.org/packages/5c/51/51c3f2884d7bab89af25f678447ea7d297b53b5a3b5730a7cb2ef6069f07/tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222", size = 242349 },
+    { url = "https://files.pythonhosted.org/packages/ab/df/bfa89627d13a5cc22402e441e8a931ef2108403db390ff3345c05253935e/tomli-2.2.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40741994320b232529c802f8bc86da4e1aa9f413db394617b9a256ae0f9a7f77", size = 252159 },
+    { url = "https://files.pythonhosted.org/packages/9e/6e/fa2b916dced65763a5168c6ccb91066f7639bdc88b48adda990db10c8c0b/tomli-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:400e720fe168c0f8521520190686ef8ef033fb19fc493da09779e592861b78c6", size = 237243 },
+    { url = "https://files.pythonhosted.org/packages/b4/04/885d3b1f650e1153cbb93a6a9782c58a972b94ea4483ae4ac5cedd5e4a09/tomli-2.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd", size = 259645 },
+    { url = "https://files.pythonhosted.org/packages/9c/de/6b432d66e986e501586da298e28ebeefd3edc2c780f3ad73d22566034239/tomli-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b82ebccc8c8a36f2094e969560a1b836758481f3dc360ce9a3277c65f374285e", size = 244584 },
+    { url = "https://files.pythonhosted.org/packages/1c/9a/47c0449b98e6e7d1be6cbac02f93dd79003234ddc4aaab6ba07a9a7482e2/tomli-2.2.1-cp312-cp312-win32.whl", hash = "sha256:889f80ef92701b9dbb224e49ec87c645ce5df3fa2cc548664eb8a25e03127a98", size = 98875 },
+    { url = "https://files.pythonhosted.org/packages/ef/60/9b9638f081c6f1261e2688bd487625cd1e660d0a85bd469e91d8db969734/tomli-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:7fc04e92e1d624a4a63c76474610238576942d6b8950a2d7f908a340494e67e4", size = 109418 },
+    { url = "https://files.pythonhosted.org/packages/04/90/2ee5f2e0362cb8a0b6499dc44f4d7d48f8fff06d28ba46e6f1eaa61a1388/tomli-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7", size = 132708 },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/46b4108816de6b385141f082ba99e315501ccd0a2ea23db4a100dd3990ea/tomli-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:286f0ca2ffeeb5b9bd4fcc8d6c330534323ec51b2f52da063b11c502da16f30c", size = 123582 },
+    { url = "https://files.pythonhosted.org/packages/a0/bd/b470466d0137b37b68d24556c38a0cc819e8febe392d5b199dcd7f578365/tomli-2.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a92ef1a44547e894e2a17d24e7557a5e85a9e1d0048b0b5e7541f76c5032cb13", size = 232543 },
+    { url = "https://files.pythonhosted.org/packages/d9/e5/82e80ff3b751373f7cead2815bcbe2d51c895b3c990686741a8e56ec42ab/tomli-2.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9316dc65bed1684c9a98ee68759ceaed29d229e985297003e494aa825ebb0281", size = 241691 },
+    { url = "https://files.pythonhosted.org/packages/05/7e/2a110bc2713557d6a1bfb06af23dd01e7dde52b6ee7dadc589868f9abfac/tomli-2.2.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e85e99945e688e32d5a35c1ff38ed0b3f41f43fad8df0bdf79f72b2ba7bc5272", size = 251170 },
+    { url = "https://files.pythonhosted.org/packages/64/7b/22d713946efe00e0adbcdfd6d1aa119ae03fd0b60ebed51ebb3fa9f5a2e5/tomli-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ac065718db92ca818f8d6141b5f66369833d4a80a9d74435a268c52bdfa73140", size = 236530 },
+    { url = "https://files.pythonhosted.org/packages/38/31/3a76f67da4b0cf37b742ca76beaf819dca0ebef26d78fc794a576e08accf/tomli-2.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:d920f33822747519673ee656a4b6ac33e382eca9d331c87770faa3eef562aeb2", size = 258666 },
+    { url = "https://files.pythonhosted.org/packages/07/10/5af1293da642aded87e8a988753945d0cf7e00a9452d3911dd3bb354c9e2/tomli-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a198f10c4d1b1375d7687bc25294306e551bf1abfa4eace6650070a5c1ae2744", size = 243954 },
+    { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724 },
+    { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383 },
+    { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257 },
 ]
 
 [[package]]
@@ -1200,6 +1457,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/35/c6/12e3aab52c11aeb289e3dbbc05929e7a9d90d7a9173958477d3ef4f8ce2d/websockets-13.1-cp313-cp313-win32.whl", hash = "sha256:624459daabeb310d3815b276c1adef475b3e6804abaf2d9d2c061c319f7f187d", size = 158709 },
     { url = "https://files.pythonhosted.org/packages/41/d8/63d6194aae711d7263df4498200c690a9c39fb437ede10f3e157a6343e0d/websockets-13.1-cp313-cp313-win_amd64.whl", hash = "sha256:c518e84bb59c2baae725accd355c8dc517b4a3ed8db88b4bc93c78dae2974bf2", size = 159144 },
     { url = "https://files.pythonhosted.org/packages/56/27/96a5cd2626d11c8280656c6c71d8ab50fe006490ef9971ccd154e0c42cd2/websockets-13.1-py3-none-any.whl", hash = "sha256:a9a396a6ad26130cdae92ae10c36af09d9bfe6cafe69670fd3b6da9b07b4044f", size = 152134 },
+]
+
+[[package]]
+name = "widgetsnbextension"
+version = "4.0.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/fc/238c424fd7f4ebb25f8b1da9a934a3ad7c848286732ae04263661eb0fc03/widgetsnbextension-4.0.13.tar.gz", hash = "sha256:ffcb67bc9febd10234a362795f643927f4e0c05d9342c727b65d2384f8feacb6", size = 1164730 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/02/88b65cc394961a60c43c70517066b6b679738caf78506a5da7b88ffcb643/widgetsnbextension-4.0.13-py3-none-any.whl", hash = "sha256:74b2692e8500525cc38c2b877236ba51d34541e6385eeed5aec15a70f88a6c71", size = 2335872 },
 ]
 
 [[package]]


### PR DESCRIPTION
Both iTables and Shiny updated to new versions which opens up new features. 

-Collected all info into one modal button
-Select-option activated for all tables (available in updated shiny package)
- Better button setup
- Now only copy visible columns
-Removing old filters and column selections to be replaced by the searchbuilder extension and the colvis button
-Added button for exporting csv for saga-script (@hkaspersen, this is for you)

Also had high hopes to implement some plotting based on data from the sequencing table, but seems like itable DT wrapper doesnt support returning selected rows yet.

deploy mode set to test, so lets see if it all works on posit before deploying on production.