### PR TITLE
Fix "Select All Filtered Rows" button logic flaw

### DIFF
--- a/src/shinylims/tables/samples.py
+++ b/src/shinylims/tables/samples.py
@@ -532,7 +532,9 @@ def samples_server(samples_df, samples_historical_df, input):
                         "text": "☑️ Select All Filtered Rows",
                         "action": JavascriptFunction("""
                             function(e, dt, node, config) {
-                                dt.rows({search: 'applied'}).select();
+                            // Replace selection (don't accumulate)
+                            dt.rows().deselect();
+                            dt.rows({ search: 'applied' }).select();
                             }
                         """)
                     },


### PR DESCRIPTION
Do not accumulate the selection, but replace it. This is more intuitive.