### PR TITLE
add pytest coverage for data_utils, upload pipeline, and query layer

### DIFF
--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import numpy as np
 import pandas as pd
 import pytest
 

--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from shinylims.integrations.data_utils import (
+    _env_flag_is_true,
+    _format_samples_dataframe,
+    _format_sequencing_dataframe,
+    _get_clarity_pg_sequencing_type_ids,
+    sanitize_dataframe_strings,
+    transform_comments_to_html,
+    transform_to_html,
+)
+
+
+# ── transform_to_html ────────────────────────────────────────────────────────
+
+def test_transform_to_html_na_passthrough():
+    assert pd.isna(transform_to_html(float("nan")))
+
+
+def test_transform_to_html_empty_string_passthrough():
+    assert transform_to_html("") == ""
+
+
+def test_transform_to_html_valid_id_produces_link():
+    result = transform_to_html("PRO-123")
+    assert 'href=' in result
+    assert "123" in result
+    assert "PRO-123" in result
+
+
+def test_transform_to_html_multiple_ids():
+    result = transform_to_html("PRO-1,PRO-2")
+    assert result.count('href=') == 2
+
+
+def test_transform_to_html_invalid_format_not_a_link():
+    result = transform_to_html("NOTANID")
+    assert 'href=' not in result
+    assert result == "NOTANID"
+
+
+def test_transform_to_html_escapes_xss_in_label():
+    result = transform_to_html("<script>-123")
+    assert "<script>" not in result
+
+
+def test_transform_to_html_whitespace_around_id_trimmed():
+    result = transform_to_html("  PRO-42  ")
+    assert 'href=' in result
+
+
+def test_transform_to_html_whitespace_around_comma_separated_ids():
+    result = transform_to_html("PRO-1 , PRO-2")
+    assert result.count('href=') == 2
+
+
+# ── transform_comments_to_html ───────────────────────────────────────────────
+
+def test_transform_comments_na_passthrough():
+    assert pd.isna(transform_comments_to_html(float("nan")))
+
+
+def test_transform_comments_empty_passthrough():
+    assert transform_comments_to_html("") == ""
+
+
+def test_transform_comments_newlines_become_br():
+    assert transform_comments_to_html("line1\nline2") == "line1<br>line2"
+
+
+def test_transform_comments_escapes_html():
+    result = transform_comments_to_html("<b>bold</b>")
+    assert "<b>" not in result
+    assert "&lt;b&gt;" in result
+
+
+def test_transform_comments_escapes_and_converts_newlines():
+    result = transform_comments_to_html("<em>note</em>\nsecond line")
+    assert "<em>" not in result
+    assert "<br>" in result
+
+
+# ── sanitize_dataframe_strings ───────────────────────────────────────────────
+
+def test_sanitize_escapes_html_in_string_columns():
+    df = pd.DataFrame({"name": ["<script>alert(1)</script>"]})
+    result = sanitize_dataframe_strings(df)
+    assert "<script>" not in result["name"][0]
+    assert "&lt;script&gt;" in result["name"][0]
+
+
+def test_sanitize_skips_listed_columns():
+    df = pd.DataFrame({"trusted": ["<b>html</b>"], "text": ["<b>unsafe</b>"]})
+    result = sanitize_dataframe_strings(df, skip_columns={"trusted"})
+    assert result["trusted"][0] == "<b>html</b>"
+    assert "<b>" not in result["text"][0]
+
+
+def test_sanitize_leaves_empty_strings_unchanged():
+    df = pd.DataFrame({"name": ["", "normal"]})
+    result = sanitize_dataframe_strings(df)
+    assert result["name"][0] == ""
+
+
+def test_sanitize_ignores_non_string_columns():
+    df = pd.DataFrame({"num": [1, 2], "flag": [True, False]})
+    result = sanitize_dataframe_strings(df)
+    assert list(result["num"]) == [1, 2]
+
+
+def test_sanitize_no_skip_columns_defaults_to_empty_set():
+    df = pd.DataFrame({"col": ["<x>"]})
+    result = sanitize_dataframe_strings(df, skip_columns=None)
+    assert "<x>" not in result["col"][0]
+
+
+# ── _env_flag_is_true ────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("value", ["1", "true", "yes", "on", "TRUE", "YES", "ON"])
+def test_env_flag_true_variants(value, monkeypatch):
+    monkeypatch.setenv("TEST_FLAG", value)
+    assert _env_flag_is_true("TEST_FLAG") is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", ""])
+def test_env_flag_false_variants(value, monkeypatch):
+    monkeypatch.setenv("TEST_FLAG", value)
+    assert _env_flag_is_true("TEST_FLAG") is False
+
+
+def test_env_flag_unset_is_false(monkeypatch):
+    monkeypatch.delenv("TEST_FLAG", raising=False)
+    assert _env_flag_is_true("TEST_FLAG") is False
+
+
+# ── _get_clarity_pg_sequencing_type_ids ─────────────────────────────────────
+
+def test_sequencing_type_ids_empty_env_returns_empty_list(monkeypatch):
+    monkeypatch.delenv("CLARITY_PG_SEQUENCING_TYPE_IDS", raising=False)
+    assert _get_clarity_pg_sequencing_type_ids() == []
+
+
+def test_sequencing_type_ids_single_value(monkeypatch):
+    monkeypatch.setenv("CLARITY_PG_SEQUENCING_TYPE_IDS", "42")
+    assert _get_clarity_pg_sequencing_type_ids() == [42]
+
+
+def test_sequencing_type_ids_multiple_values_with_spaces(monkeypatch):
+    monkeypatch.setenv("CLARITY_PG_SEQUENCING_TYPE_IDS", "42, 99, 7")
+    assert _get_clarity_pg_sequencing_type_ids() == [42, 99, 7]
+
+
+def test_sequencing_type_ids_trailing_comma_ignored(monkeypatch):
+    monkeypatch.setenv("CLARITY_PG_SEQUENCING_TYPE_IDS", "42,")
+    assert _get_clarity_pg_sequencing_type_ids() == [42]
+
+
+# ── _format_sequencing_dataframe ─────────────────────────────────────────────
+
+def test_format_sequencing_converts_seq_date_to_datetime():
+    df = pd.DataFrame({"seq_limsid": ["PRO-1"], "Seq Date": ["2024-03-15"]})
+    result = _format_sequencing_dataframe(df)
+    assert pd.api.types.is_datetime64_any_dtype(result["Seq Date"])
+
+
+def test_format_sequencing_limsid_becomes_html_link():
+    df = pd.DataFrame({"seq_limsid": ["PRO-123"]})
+    result = _format_sequencing_dataframe(df)
+    assert 'href=' in result["seq_limsid"][0]
+
+
+def test_format_sequencing_nan_replaced_with_empty_string():
+    df = pd.DataFrame({"seq_limsid": [float("nan")], "Run ID": [float("nan")]})
+    result = _format_sequencing_dataframe(df)
+    assert result["Run ID"][0] == ""
+
+
+def test_format_sequencing_text_columns_are_escaped():
+    df = pd.DataFrame({"Instrument": ["<MiSeq>"], "seq_limsid": ["PRO-1"]})
+    result = _format_sequencing_dataframe(df)
+    assert "<MiSeq>" not in result["Instrument"][0]
+
+
+# ── _format_samples_dataframe ────────────────────────────────────────────────
+
+def test_format_samples_storage_box_placed_immediately_before_storage_well():
+    df = pd.DataFrame({
+        "Sample Name": ["S1"],
+        "Storage Well": ["A1"],
+        "Storage Box": ["Box1"],
+    })
+    result_df, _ = _format_samples_dataframe(df, meta_created="2024-01-01")
+    cols = list(result_df.columns)
+    assert cols.index("Storage Box") == cols.index("Storage Well") - 1
+
+
+def test_format_samples_comment_newlines_converted_to_br():
+    df = pd.DataFrame({"comment": ["line1\nline2"]})
+    result_df, _ = _format_samples_dataframe(df, meta_created="2024-01-01")
+    assert "<br>" in result_df["comment"][0]
+
+
+def test_format_samples_returns_meta_created_unchanged():
+    df = pd.DataFrame({"Sample Name": ["S1"]})
+    _, meta = _format_samples_dataframe(df, meta_created="2024-01-01T12:00:00")
+    assert meta == "2024-01-01T12:00:00"
+
+
+def test_format_samples_nan_replaced_with_empty_string():
+    df = pd.DataFrame({"Species": [float("nan")]})
+    result_df, _ = _format_samples_dataframe(df, meta_created="2024-01-01")
+    assert result_df["Species"][0] == ""

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,0 +1,276 @@
+"""
+Tests for the Clarity Postgres query layer.
+
+Pure-function helpers are tested directly. Row-builder functions that require
+a SQLAlchemy Session are tested with a lightweight fake session that returns
+controlled row data without any real database connection.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from shinylims.integrations.queries._shared import (
+    PROJECT_IDS_EXCLUDED_FROM_APP,
+    _container_state_label,
+    _display_name,
+    _load_artifact_udfs,
+    _load_operator_initials,
+    _load_process_udfs,
+)
+from shinylims.integrations.queries.projects import (
+    PROJECT_COMMENT_PLACEHOLDERS,
+    build_project_rows,
+)
+from shinylims.integrations.queries.storage import build_storage_container_rows
+
+
+# ── Fake session infrastructure ──────────────────────────────────────────────
+
+class _FakeResult:
+    def __init__(self, rows: list) -> None:
+        self._rows = rows
+
+    def all(self) -> list:
+        return self._rows
+
+
+class _FakeSession:
+    def __init__(self, rows: list) -> None:
+        self._rows = rows
+
+    def execute(self, stmt: Any) -> _FakeResult:
+        return _FakeResult(self._rows)
+
+    def __enter__(self) -> _FakeSession:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        pass
+
+
+class _NeverCalledSession:
+    """Sentinel session that fails if execute() is ever called."""
+
+    def execute(self, *args: Any, **kwargs: Any) -> None:
+        raise AssertionError("session.execute should not be called with empty input")
+
+
+# ── _display_name ────────────────────────────────────────────────────────────
+
+def test_display_name_both_parts():
+    assert _display_name("John", "Doe") == "John Doe"
+
+
+def test_display_name_only_first():
+    assert _display_name("John", None) == "John"
+
+
+def test_display_name_only_last():
+    assert _display_name(None, "Doe") == "Doe"
+
+
+def test_display_name_both_none_returns_none():
+    assert _display_name(None, None) is None
+
+
+def test_display_name_strips_whitespace():
+    assert _display_name("  John  ", "  Doe  ") == "John Doe"
+
+
+def test_display_name_empty_strings_returns_none():
+    assert _display_name("", "") is None
+
+
+# ── _container_state_label ───────────────────────────────────────────────────
+
+def test_container_state_label_active():
+    assert _container_state_label(2) == "Active"
+
+
+def test_container_state_label_discarded():
+    assert _container_state_label(4) == "Discarded"
+
+
+def test_container_state_label_unknown_state_returns_none():
+    assert _container_state_label(99) is None
+
+
+def test_container_state_label_none_returns_none():
+    assert _container_state_label(None) is None
+
+
+# ── Empty-input short-circuits ───────────────────────────────────────────────
+
+def test_load_process_udfs_empty_ids_returns_empty_dict():
+    assert _load_process_udfs(_NeverCalledSession(), [], {"udf"}) == {}
+
+
+def test_load_process_udfs_empty_udf_names_returns_empty_dict():
+    assert _load_process_udfs(_NeverCalledSession(), [1], set()) == {}
+
+
+def test_load_artifact_udfs_empty_ids_returns_empty_dict():
+    assert _load_artifact_udfs(_NeverCalledSession(), [], {"udf"}) == {}
+
+
+def test_load_artifact_udfs_empty_udf_names_returns_empty_dict():
+    assert _load_artifact_udfs(_NeverCalledSession(), [1], set()) == {}
+
+
+def test_load_operator_initials_empty_ids_returns_empty_dict():
+    assert _load_operator_initials(_NeverCalledSession(), []) == {}
+
+
+# ── build_project_rows helpers ───────────────────────────────────────────────
+
+def _project_row(**overrides: Any) -> SimpleNamespace:
+    defaults: dict[str, Any] = dict(
+        projectid=1,
+        luid="LEI001",
+        opendate=datetime(2024, 1, 1),
+        closedate=None,
+        project_name="Test Project",
+        firstname="John",
+        lastname="Doe",
+        lab_name="Test Lab",
+        sample_processid=101,
+        species="E. coli",
+        comment=None,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+# ── build_project_rows ───────────────────────────────────────────────────────
+
+def test_build_project_rows_open_project():
+    rows = build_project_rows(_FakeSession([_project_row()]))
+    assert len(rows) == 1
+    assert rows[0]["Status"] == "OPEN"
+
+
+def test_build_project_rows_closed_project():
+    rows = build_project_rows(
+        _FakeSession([_project_row(closedate=datetime(2024, 6, 1))])
+    )
+    assert rows[0]["Status"] == "CLOSED"
+
+
+def test_build_project_rows_pending_project():
+    rows = build_project_rows(
+        _FakeSession([_project_row(opendate=None, closedate=None)])
+    )
+    assert rows[0]["Status"] == "PENDING"
+
+
+def test_build_project_rows_counts_unique_samples():
+    data = [
+        _project_row(sample_processid=101),
+        _project_row(sample_processid=101),  # duplicate – counted once
+        _project_row(sample_processid=102),
+    ]
+    rows = build_project_rows(_FakeSession(data))
+    assert rows[0]["Samples"] == 2
+
+
+def test_build_project_rows_no_samples_when_processid_is_none():
+    rows = build_project_rows(_FakeSession([_project_row(sample_processid=None)]))
+    assert rows[0]["Samples"] == 0
+
+
+def test_build_project_rows_aggregates_species_deduped():
+    data = [
+        _project_row(species="E. coli"),
+        _project_row(species="S. aureus"),
+        _project_row(species="E. coli"),  # duplicate
+    ]
+    rows = build_project_rows(_FakeSession(data))
+    assert rows[0]["Species"] == "E. coli, S. aureus"
+
+
+def test_build_project_rows_no_species_is_empty_string():
+    rows = build_project_rows(_FakeSession([_project_row(species=None)]))
+    assert rows[0]["Species"] == ""
+
+
+def test_build_project_rows_filters_placeholder_comments():
+    for placeholder in PROJECT_COMMENT_PLACEHOLDERS:
+        rows = build_project_rows(_FakeSession([_project_row(comment=placeholder)]))
+        assert rows[0]["Comment"] == ""
+
+
+def test_build_project_rows_preserves_real_comment():
+    rows = build_project_rows(_FakeSession([_project_row(comment="Rush order")]))
+    assert rows[0]["Comment"] == "Rush order"
+
+
+def test_build_project_rows_excludes_blocked_project_ids():
+    blocked = next(iter(PROJECT_IDS_EXCLUDED_FROM_APP))
+    rows = build_project_rows(_FakeSession([_project_row(luid=blocked)]))
+    assert rows == []
+
+
+def test_build_project_rows_includes_non_blocked_project():
+    rows = build_project_rows(_FakeSession([_project_row(luid="LEI999")]))
+    assert len(rows) == 1
+
+
+def test_build_project_rows_empty_db_returns_empty_list():
+    assert build_project_rows(_FakeSession([])) == []
+
+
+def test_build_project_rows_submitter_display_name():
+    rows = build_project_rows(_FakeSession([_project_row(firstname="Ada", lastname="Lovelace")]))
+    assert rows[0]["Submitter"] == "Ada Lovelace"
+
+
+# ── build_storage_container_rows ─────────────────────────────────────────────
+
+def _storage_row(
+    name: str = "Box-001",
+    stateid: int = 2,
+    createddate: datetime = datetime(2024, 1, 1),
+    lastmodifieddate: datetime = datetime(2024, 6, 1),
+) -> tuple:
+    return (name, stateid, createddate, lastmodifieddate)
+
+
+def test_build_storage_rows_active_state_label():
+    rows = build_storage_container_rows(_FakeSession([_storage_row(stateid=2)]))
+    assert rows[0]["Status"] == "Active"
+
+
+def test_build_storage_rows_discarded_state_label():
+    rows = build_storage_container_rows(_FakeSession([_storage_row(stateid=4)]))
+    assert rows[0]["Status"] == "Discarded"
+
+
+def test_build_storage_rows_unknown_state_uses_numeric_fallback():
+    rows = build_storage_container_rows(_FakeSession([_storage_row(stateid=99)]))
+    assert rows[0]["Status"] == "State 99"
+
+
+def test_build_storage_rows_empty_db_returns_empty_list():
+    assert build_storage_container_rows(_FakeSession([])) == []
+
+
+def test_build_storage_rows_maps_column_names():
+    rows = build_storage_container_rows(_FakeSession([_storage_row(name="MyBox")]))
+    assert rows[0]["Box Name"] == "MyBox"
+    assert "Created Date" in rows[0]
+    assert "Last Modified" in rows[0]
+
+
+def test_build_storage_rows_preserves_dates():
+    created = datetime(2023, 3, 15)
+    modified = datetime(2024, 7, 4)
+    rows = build_storage_container_rows(
+        _FakeSession([_storage_row(createddate=created, lastmodifieddate=modified)])
+    )
+    assert rows[0]["Created Date"] == created
+    assert rows[0]["Last Modified"] == modified

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -12,8 +12,6 @@ from datetime import datetime
 from types import SimpleNamespace
 from typing import Any
 
-import pytest
-
 from shinylims.integrations.queries._shared import (
     PROJECT_IDS_EXCLUDED_FROM_APP,
     _container_state_label,

--- a/tests/test_upload_atlas_file_to_saga.py
+++ b/tests/test_upload_atlas_file_to_saga.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from shinylims.integrations.upload_atlas_file_to_saga import (
+    _preflight_check,
+    _validate_atlas_csv,
+)
+
+VALID_CSV = "Sample Name,NIRD Filename\nSample1,file1.fastq\nSample2,file2.fastq\n"
+
+
+def make_buffer(content: str = VALID_CSV) -> io.StringIO:
+    return io.StringIO(content)
+
+
+# ── _validate_atlas_csv ──────────────────────────────────────────────────────
+
+def test_validate_atlas_csv_valid_passes():
+    _validate_atlas_csv(make_buffer())  # must not raise
+
+
+def test_validate_atlas_csv_empty_file_raises():
+    with pytest.raises(RuntimeError, match="empty or missing"):
+        _validate_atlas_csv(io.StringIO(""))
+
+
+def test_validate_atlas_csv_header_only_no_rows_passes():
+    _validate_atlas_csv(make_buffer("Sample Name,NIRD Filename\n"))
+
+
+def test_validate_atlas_csv_missing_nird_filename_column_raises():
+    buf = make_buffer("Sample Name,Other Column\nS1,x\n")
+    with pytest.raises(RuntimeError, match="missing required column"):
+        _validate_atlas_csv(buf)
+
+
+def test_validate_atlas_csv_missing_sample_name_column_raises():
+    buf = make_buffer("NIRD Filename,Other\nfile1.fastq,x\n")
+    with pytest.raises(RuntimeError, match="missing required column"):
+        _validate_atlas_csv(buf)
+
+
+def test_validate_atlas_csv_empty_sample_name_raises():
+    buf = make_buffer("Sample Name,NIRD Filename\n,file1.fastq\n")
+    with pytest.raises(RuntimeError, match="empty"):
+        _validate_atlas_csv(buf)
+
+
+def test_validate_atlas_csv_empty_nird_filename_raises():
+    buf = make_buffer("Sample Name,NIRD Filename\nSample1,\n")
+    with pytest.raises(RuntimeError, match="empty"):
+        _validate_atlas_csv(buf)
+
+
+def test_validate_atlas_csv_whitespace_only_values_count_as_empty():
+    buf = make_buffer("Sample Name,NIRD Filename\n   ,file1.fastq\n")
+    with pytest.raises(RuntimeError, match="empty"):
+        _validate_atlas_csv(buf)
+
+
+def test_validate_atlas_csv_resets_seek_position_after_validation():
+    buf = make_buffer()
+    _validate_atlas_csv(buf)
+    assert buf.tell() == 0
+
+
+def test_validate_atlas_csv_reports_bad_row_numbers():
+    buf = make_buffer("Sample Name,NIRD Filename\nGood,file.fastq\n,missing_sample\n")
+    with pytest.raises(RuntimeError, match="row"):
+        _validate_atlas_csv(buf)
+
+
+# ── _preflight_check ─────────────────────────────────────────────────────────
+
+def test_preflight_valid_inputs_pass():
+    _preflight_check(
+        make_buffer(), "validuser", "123456", "secret", "/cluster/shared/out.csv"
+    )
+
+
+def test_preflight_empty_username_raises():
+    with pytest.raises(RuntimeError, match="[Uu]sername"):
+        _preflight_check(make_buffer(), "", "123456", "secret", "/cluster/shared/out.csv")
+
+
+def test_preflight_username_with_asterisk_raises():
+    with pytest.raises(RuntimeError, match=r"\*"):
+        _preflight_check(
+            make_buffer(), "user*name", "123456", "secret", "/cluster/shared/out.csv"
+        )
+
+
+def test_preflight_username_with_uppercase_raises():
+    with pytest.raises(RuntimeError, match="Invalid username"):
+        _preflight_check(
+            make_buffer(), "UserName", "123456", "secret", "/cluster/shared/out.csv"
+        )
+
+
+def test_preflight_username_with_space_raises():
+    with pytest.raises(RuntimeError, match="Invalid username"):
+        _preflight_check(
+            make_buffer(), "user name", "123456", "secret", "/cluster/shared/out.csv"
+        )
+
+
+def test_preflight_username_starting_with_digit_raises():
+    with pytest.raises(RuntimeError, match="Invalid username"):
+        _preflight_check(
+            make_buffer(), "1user", "123456", "secret", "/cluster/shared/out.csv"
+        )
+
+
+def test_preflight_empty_totp_raises():
+    with pytest.raises(RuntimeError, match="2FA"):
+        _preflight_check(make_buffer(), "validuser", "", "secret", "/cluster/shared/out.csv")
+
+
+def test_preflight_non_digit_totp_raises():
+    with pytest.raises(RuntimeError, match="digit"):
+        _preflight_check(
+            make_buffer(), "validuser", "abc123", "secret", "/cluster/shared/out.csv"
+        )
+
+
+def test_preflight_totp_too_short_raises():
+    with pytest.raises(RuntimeError, match="six digits"):
+        _preflight_check(
+            make_buffer(), "validuser", "12345", "secret", "/cluster/shared/out.csv"
+        )
+
+
+def test_preflight_totp_too_long_raises():
+    with pytest.raises(RuntimeError, match="six digits"):
+        _preflight_check(
+            make_buffer(), "validuser", "1234567", "secret", "/cluster/shared/out.csv"
+        )
+
+
+def test_preflight_empty_password_raises():
+    with pytest.raises(RuntimeError, match="[Pp]assword"):
+        _preflight_check(make_buffer(), "validuser", "123456", "", "/cluster/shared/out.csv")
+
+
+def test_preflight_empty_saga_location_raises():
+    with pytest.raises(RuntimeError, match="[Ll]ocation"):
+        _preflight_check(make_buffer(), "validuser", "123456", "secret", "")
+
+
+def test_preflight_relative_saga_location_raises():
+    with pytest.raises(RuntimeError, match="absolute"):
+        _preflight_check(
+            make_buffer(), "validuser", "123456", "secret", "relative/path/out.csv"
+        )
+
+
+def test_preflight_saga_location_without_csv_extension_raises():
+    with pytest.raises(RuntimeError, match=r"\.csv"):
+        _preflight_check(
+            make_buffer(), "validuser", "123456", "secret", "/cluster/shared/out.txt"
+        )
+
+
+def test_preflight_saga_location_directory_only_raises():
+    with pytest.raises(RuntimeError, match=r"\.csv"):
+        _preflight_check(
+            make_buffer(), "validuser", "123456", "secret", "/cluster/shared/"
+        )
+
+
+def test_preflight_underscore_in_username_is_valid():
+    _preflight_check(
+        make_buffer(), "valid_user", "123456", "secret", "/cluster/shared/out.csv"
+    )
+
+
+def test_preflight_hyphen_in_username_is_valid():
+    _preflight_check(
+        make_buffer(), "valid-user", "123456", "secret", "/cluster/shared/out.csv"
+    )


### PR DESCRIPTION
104 new tests across three files covering HTML transformation/sanitization, ATLAS CSV validation and preflight checks, and Clarity Postgres query helpers.