### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/NorwegianVeterinaryInstitute/shinylims/security/code-scanning/2](https://github.com/NorwegianVeterinaryInstitute/shinylims/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/test.yml` at the workflow root so it applies to all jobs by default. The least-privilege baseline for this workflow is:

- `contents: read`

This preserves existing behavior (`actions/checkout` can read repository contents) while ensuring the token is not implicitly granted broader rights if repo/org defaults are permissive or change later.

Change location: directly after the `on:` trigger block (before `jobs:`), or near the top of the workflow. No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
