### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,9 @@
 # Deploy branch is followed by Posit Connect
 name: Update Requirements and Manifest on Deploy Branch
 
+permissions:
+  contents: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/NorwegianVeterinaryInstitute/shinylims/security/code-scanning/1](https://github.com/NorwegianVeterinaryInstitute/shinylims/security/code-scanning/1)

Add an explicit `permissions` block to the workflow (or the job) to enforce least privilege while preserving behavior.  
Because this workflow commits and pushes to branches, it requires `contents: write`. No other scopes are needed by the shown steps.

Best single fix here: add workflow-level permissions directly under `name`/before `on`:

- `permissions:`
  - `contents: write`

This keeps current functionality (checkout, commit, push) and removes reliance on repository defaults.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
